### PR TITLE
v1.0.2

### DIFF
--- a/autoload/indent_blankline.vim
+++ b/autoload/indent_blankline.vim
@@ -1,7 +1,7 @@
 
 function! indent_blankline#Init()
 
-    if len(nvim_list_uis()) ==# 0 || g:indent_blankline_enabled !=# 1
+    if len(nvim_list_uis()) ==# 0 || g:indent_blankline_enabled !=# v:true
         return
     endif
 
@@ -46,7 +46,7 @@ function! indent_blankline#BufferEnabled()
         return v:false
     endif
 
-    for name in g:indentLine_bufNameExclude
+    for name in g:indent_blankline_bufname_exclude
         if matchstr(bufname(''), name) == bufname('')
             return v:false
         endif
@@ -58,7 +58,7 @@ endfunction
 
 function! indent_blankline#Refresh()
 
-    if g:indent_blankline_enabled !=# 1 || !indent_blankline#BufferEnabled()
+    if g:indent_blankline_enabled !=# v:true || !indent_blankline#BufferEnabled()
         if get(b:, 'set_indent_blankline', v:false) && exists('g:indent_blankline_namespace')
             call nvim_buf_clear_namespace(0, g:indent_blankline_namespace, 1, -1)
         endif

--- a/autoload/indent_blankline/callback.vim
+++ b/autoload/indent_blankline/callback.vim
@@ -13,10 +13,10 @@ function! indent_blankline#callback#ApplyMatches(result, bufnr)
 
         for i in range(min([ l:match['indent'] / l:space, g:indent_blankline_indent_level ]))
             if n > 0
-                let char = g:indent_blankline_char_list[level % n]
-                let level += 1
+                let l:char = g:indent_blankline_char_list[level % n]
+                let l:level += 1
             else
-                let char = g:indent_blankline_char
+                let l:char = g:indent_blankline_char
             endif
 
             call add(l:v_text, [repeat(g:indent_blankline_space_char, l:space - 1), 'Whitespace'])

--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -2,7 +2,7 @@
 
 
 Author: Lukas Reineke <lukas.reineke@protonmail.com>
-Version: 1.0.1
+Version: 1.0.2
 
 ==============================================================================
 CONTENTS                                                    *indent-blankline*
@@ -225,6 +225,10 @@ IndentBlanklineToggleAll                            *IndentBlanklineToggleAll*
 
 ==============================================================================
  4. CHANGELOG                                           *indentLine-changelog*
+
+1.0.2
+* Fixed wrong variable reference form `indentLine_bufTypeExclude`
+  to `indent_blankline_buftype_exclude`
 
 1.0.1
   * Fixed typo in docs

--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -100,6 +100,19 @@ g:indent_blankline_enabled                        *g:indent_blankline_enabled*
         let g:indent_blankline_enabled = v:false
 
 ------------------------------------------------------------------------------
+b:indent_blankline_enabled                        *b:indent_blankline_enabled*
+
+    Turns this plugin on or off for the buffer.
+
+    Also set by |b:indentLine_enabled|
+
+    Default: v:true                                                          ~
+
+    Example: >
+
+        let b:indent_blankline_enabled = v:false
+
+------------------------------------------------------------------------------
 g:indent_blankline_filetype                      *g:indent_blankline_filetype*
 
     Specifies a list of |filetype| values for which this plugin is enabled.


### PR DESCRIPTION
# Changelog

* Fixed wrong variable reference form `indentLine_bufTypeExclude` to `indent_blankline_buftype_exclude`