### PR TITLE
doc: correct tag for changelog to avoid duplicate helptag issue

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -224,7 +224,7 @@ IndentBlanklineToggleAll                            *IndentBlanklineToggleAll*
     available.
 
 ==============================================================================
- 4. CHANGELOG                                           *indentLine-changelog*
+ 4. CHANGELOG                                           *indent-blankline-changelog*
 
 1.0.2
 * Fixed wrong variable reference form `indentLine_bufTypeExclude`


### PR DESCRIPTION
When installing this plugin using `dein` (and I would assume other plugin managers that auto-generate helptags as well), there is an issue with a duplicate helptag if `indentLine` is also installed:

```
[dein] Error generating helptags:
[dein] Vim(helptags):E154: Duplicate tag "indentLine-changelog" in file ~.cache/dein/.cache/init.vim/.dein/doc/indent_blankline.txt
[dein] function <lambda>1[1]..dein#install#_polling[1]..<SNR>18_install_async[9]..<SNR>18_done[7]..dein#install#_recache_runtimepath[20]..<SNR>18_helptags, line 12
```

This PR changes this tag to be unique to `indent-blankline,` avoiding conflicts.

Thanks for creating this plugin!