### PR TITLE
1.1.0

### DIFF
--- a/autoload/indent_blankline.vim
+++ b/autoload/indent_blankline.vim
@@ -84,6 +84,8 @@ function! indent_blankline#Refresh()
     catch /E475/
         call indent_blankline#Init()
         return
+    catch
+        echom 'indent_blankline encountered an error: ' . v:exception
     endtry
 
     let b:set_indent_blankline = v:true

--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -2,7 +2,7 @@
 
 
 Author: Lukas Reineke <lukas.reineke@protonmail.com>
-Version: 1.0.3
+Version: 1.1.0
 
 ==============================================================================
 CONTENTS                                                    *indent-blankline*
@@ -224,7 +224,11 @@ IndentBlanklineToggleAll                            *IndentBlanklineToggleAll*
     available.
 
 ==============================================================================
- 4. CHANGELOG                                           *indent-blankline-changelog*
+ 4. CHANGELOG                                     *indent-blankline-changelog*
+
+1.1.0
+ * Don't throw errors when `rpcnotify` fails. Just print the error message and
+   try again next time.
 
 1.0.3
  * Fixed wrong help tag


### PR DESCRIPTION
# Changelog
 * Don't throw errors when `rpcnotify` fails. Just print the error message and
   try again next time.