### PR TITLE
1.4.0

### DIFF
--- a/autoload/indent_blankline/commands.vim
+++ b/autoload/indent_blankline/commands.vim
@@ -7,7 +7,9 @@ endfunction
 function! indent_blankline#commands#Disable()
     let b:indent_blankline_enabled = v:false
     let b:set_indent_blankline = v:false
-    call nvim_buf_clear_namespace(0, g:indent_blankline_namespace, 1, -1)
+    if exists('g:indent_blankline_namespace')
+        call nvim_buf_clear_namespace(0, g:indent_blankline_namespace, 1, -1)
+    endif
 endfunction
 
 function! indent_blankline#commands#Toggle()

--- a/autoload/indent_blankline/embedded.vim
+++ b/autoload/indent_blankline/embedded.vim
@@ -1,7 +1,9 @@
 
 function! indent_blankline#embedded#FindMatches(file, bufnr)
     try
+        keepjumps
         execute ':edit ' . a:file
+        let l:view = winsaveview()
         call cursor(1, 1)
 
         let l:matches = []
@@ -34,5 +36,10 @@ function! indent_blankline#embedded#FindMatches(file, bufnr)
         call rpcrequest(1, 'vim_eval', 'indent_blankline#callback#ApplyMatches([' . join(l:matches, ', ') . '], ' . a:bufnr . ')')
     catch
         call rpcrequest(1, 'vim_eval', 'indent_blankline#callback#Error("' . v:exception . '")')
+    finally
+        if exists('l:view')
+            call winrestview(l:view)
+            bdelete
+        endif
     endtry
 endfunction

--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -2,7 +2,7 @@
 
 
 Author: Lukas Reineke <lukas.reineke@protonmail.com>
-Version: 1.3.2
+Version: 1.4.0
 
 ==============================================================================
 CONTENTS                                                    *indent-blankline*
@@ -248,6 +248,11 @@ IndentBlanklineToggleAll                            *IndentBlanklineToggleAll*
 
 ==============================================================================
  4. CHANGELOG                                     *indent-blankline-changelog*
+
+1.4.0
+ * Don't create jumps in embedded nvim instance
+ * Restore cursor and close buffer after every search
+ * Only clear the namespace on disable if it exists
 
 1.3.2
  * Call indentexpr with `silent!` to not exit early on errors


### PR DESCRIPTION
# Changelog

 * Don't create jumps in embedded nvim instance
 * Restore cursor and close buffer after every search
 * Only clear the namespace on disable if it exists