### PR TITLE
Show visual selections for indentations

### DIFF
--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -126,7 +126,7 @@ local refresh = function()
                                 vim.g.indent_blankline_namespace,
                                 i - 1 + offset,
                                 0,
-                                {virt_text = virtual_text, virt_text_pos = "overlay"}
+                                {virt_text = virtual_text, virt_text_pos = "overlay", hl_mode = "combine"}
                             )
                         end
                     )()
@@ -172,7 +172,7 @@ local refresh = function()
                             vim.g.indent_blankline_namespace,
                             i - 1 + offset,
                             0,
-                            {virt_text = virtual_text, virt_text_pos = "overlay"}
+                            {virt_text = virtual_text, virt_text_pos = "overlay", hl_mode = "combine"}
                         )
                     end
                 )()


### PR DESCRIPTION
Fixes #41.

Using the new `hl_mode` option for `nvim_buf_set_extmark` added recently: https://github.com/neovim/neovim/pull/14065

**Before:**

![image](https://user-images.githubusercontent.com/32966690/110766498-15aee780-820a-11eb-9f47-643b22e6d58a.png)

**After:**

![image](https://user-images.githubusercontent.com/32966690/110766404-fca63680-8209-11eb-8ce1-57013c921dd4.png)


**Known issues:**

This appears to break indent lines on versions of Neovim which do not have the `hl_mode` option, so you might want to wait a few days to merge this for people to update their Neovim.