### PR TITLE
Context highlight list

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -367,7 +367,7 @@ g:indent_blankline_context_highlight_list*g:indent_blankline_context_highlight_l
 
     Example: >
 
-        let g:indent_blankline_context_highlight = 'Error'
+        let g:indent_blankline_context_highlight_list = ['Error', 'Warning']
 
 ------------------------------------------------------------------------------
 g:indent_blankline_context_patterns      *g:indent_blankline_context_patterns*

--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -355,6 +355,21 @@ g:indent_blankline_context_highlight    *g:indent_blankline_context_highlight*
         let g:indent_blankline_context_highlight = 'Error'
 
 ------------------------------------------------------------------------------
+g:indent_blankline_context_highlight_list*g:indent_blankline_context_highlight_list*
+
+    Specifies the list of character highlights for the current context at
+    each indentation level.
+    Ignored if the value is an empty list.
+
+    Only used when |g:indent_blankline_show_current_context| is active
+
+    Default: '[]'                                                         ~
+
+    Example: >
+
+        let g:indent_blankline_context_highlight = 'Error'
+
+------------------------------------------------------------------------------
 g:indent_blankline_context_patterns      *g:indent_blankline_context_patterns*
 
     Specifies the treesitter |tsnode:type()| pattern for which determine the

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -44,6 +44,7 @@ local refresh = function()
     local space = utils._if(tabs, vim.bo.tabstop, vim.bo.shiftwidth)
 
     local context_highlight = vim.g.indent_blankline_context_highlight
+    local context_highlight_list = vim.g.indent_blankline_context_highlight_list
     local context_status, context_start, context_end = false, 0, 0
     if vim.g.indent_blankline_show_current_context then
         context_status, context_start, context_end = utils.get_current_context(vim.g.indent_blankline_context_patterns)
@@ -66,7 +67,11 @@ local refresh = function()
                         ),
                         utils._if(
                             context,
-                            context_highlight,
+                            utils._if(
+                              #context_highlight_list > 0,
+                              utils.get_from_list(context_highlight_list, i),
+                              context_highlight
+                            ),
                             utils._if(
                                 #char_highlight_list > 0,
                                 utils.get_from_list(char_highlight_list, i),

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -109,7 +109,11 @@ local refresh = function()
                     utils._if(#char_list > 0, utils.get_from_list(char_list, math.ceil(#virtual_text / 2) + 1), char),
                     utils._if(
                         context_active and context_indent == #virtual_text,
-                        context_highlight,
+                        utils._if(
+                            #context_highlight_list > 0,
+                            utils.get_from_list(context_highlight_list, math.ceil(#virtual_text / 2) + 1),
+                            context_highlight
+                        ),
                         utils._if(
                             #char_highlight_list > 0,
                             utils.get_from_list(char_highlight_list, math.ceil(#virtual_text / 2) + 1),

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -68,9 +68,9 @@ local refresh = function()
                         utils._if(
                             context,
                             utils._if(
-                              #context_highlight_list > 0,
-                              utils.get_from_list(context_highlight_list, i),
-                              context_highlight
+                                #context_highlight_list > 0,
+                                utils.get_from_list(context_highlight_list, i),
+                                context_highlight
                             ),
                             utils._if(
                                 #char_highlight_list > 0,

--- a/plugin/indent_blankline.vim
+++ b/plugin/indent_blankline.vim
@@ -33,6 +33,7 @@ let g:indent_blankline_show_trailing_blankline_indent = get(g:, 'indent_blanklin
 let g:indent_blankline_show_end_of_line = get(g:, 'indent_blankline_show_end_of_line', v:false)
 let g:indent_blankline_show_current_context = get(g:, 'indent_blankline_show_current_context', v:false)
 let g:indent_blankline_context_highlight = get(g:, 'indent_blankline_context_highlight', 'Label')
+let g:indent_blankline_context_highlight_list = get(g:, 'indent_blankline_context_highlight_list', [])
 let g:indent_blankline_context_patterns = get(g:, 'indent_blankline_context_patterns', ['class', 'function', 'method'])
 let g:indent_blankline_strict_tabs = get(g:, 'indent_blankline_strict_tabs', v:false)
 


### PR DESCRIPTION
This PR adds a list for defining different highlights at different levels with context highlighting. Currently there is no synchronization between brace/paren/other scope delimiter and the indent line color. It is just coincidental that the colors of the braces and the line match in the second image.
![image](https://user-images.githubusercontent.com/9094640/112109980-a41b5580-8b88-11eb-9f06-856a8a558e92.png)
![image](https://user-images.githubusercontent.com/9094640/112110048-c1502400-8b88-11eb-8aaf-ee85f0c8e5de.png)
