### PR TITLE
draft | lua: added support for customising indent

### DIFF
--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -139,7 +139,7 @@ local refresh = function()
 
     local get_virtual_text = function(indent, extra, blankline, context_active, context_indent)
         local virtual_text = {}
-        for i = utils.if(first_indent, 1, 2), math.min(math.max(indent, 0), max_indent_level) do
+        for i = utils._if(first_indent, 1, 2), math.min(math.max(indent, 0), max_indent_level) do
             local context = context_active and context_indent == i
             -- first char in indent:
                 if( i == 1 and blankline and end_of_line and #end_of_line_char > 0 ) then

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -67,58 +67,176 @@ local refresh = function()
 
     local get_virtual_text = function(indent, extra, blankline, context_active, context_indent)
         local virtual_text = {}
-        for i = 1, math.min(math.max(indent, 0), max_indent_level) do
-            local space_count = space
+		-- first indent:
+
+        for i = 2, math.min(math.max(indent, 0), max_indent_level) do
             local context = context_active and context_indent == i
-            if i ~= 1 or first_indent then
-                space_count = space_count - 1
-                table.insert(
-                    virtual_text,
-                    {
-                        utils._if(
-                            i == 1 and blankline and end_of_line and #end_of_line_char > 0,
-                            end_of_line_char,
-                            utils._if(
-                                #char_list > 0,
-                                utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
-                                char
-                            )
-                        ),
-                        utils._if(
-                            context,
-                            utils._if(
-                                #context_highlight_list > 0,
-                                utils.get_from_list(context_highlight_list, i),
-                                context_highlight
-                            ),
-                            utils._if(
-                                #char_highlight_list > 0,
-                                utils.get_from_list(char_highlight_list, i),
-                                char_highlight
-                            )
-                        )
-                    }
-                )
-            end
-            table.insert(
-                virtual_text,
-                {
-                    utils._if(blankline, space_char_blankline, space_char):rep(space_count),
-                    utils._if(
-                        blankline,
-                        utils._if(
-                            #space_char_blankline_highlight_list > 0,
-                            utils.get_from_list(space_char_blankline_highlight_list, i),
-                            space_char_blankline_highlight
-                        ),
-                        utils._if(
-                            #space_char_highlight_list > 0,
-                            utils.get_from_list(space_char_highlight_list, i),
-                            space_char_highlight
-                        )
-                    )
-                }
-            )
+			-- first char in indent:
+				table.insert(
+					virtual_text,
+					{
+						utils._if(
+							i == 1 and blankline and end_of_line and #end_of_line_char > 0,
+							end_of_line_char,
+							utils._if(
+								#char_list > 0,
+								utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
+								char
+							)
+						),
+						utils._if(
+							context,
+							utils._if(
+								#context_highlight_list > 0,
+								utils.get_from_list(context_highlight_list, i),
+								context_highlight
+							),
+							utils._if(
+								#char_highlight_list > 0,
+								utils.get_from_list(char_highlight_list, i),
+								char_highlight
+							)
+						)
+					}
+				)
+			-- middle char in indent:
+				for space_count = 2, space-1 do
+					if g:indent_blankline_char_middle == ' ' then
+						table.insert(
+							virtual_text,
+							{
+								utils._if(
+									utils._if(blankline, space_char_blankline, space_char),
+									utils._if(
+										blankline,
+										utils._if(
+											#space_char_blankline_highlight_list > 0,
+											utils.get_from_list(space_char_blankline_highlight_list, i),
+											space_char_blankline_highlight
+										),
+										utils._if(
+											#space_char_highlight_list > 0,
+											utils.get_from_list(space_char_highlight_list, i),
+											space_char_highlight
+										)
+									)
+								)
+							}
+						)
+					elseif g:indent_blankline_char_middle == '|' then
+						table.insert(
+							virtual_text,
+							{
+								utils._if(
+									#char_list > 0,
+									utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
+									char
+								),
+								utils._if(
+									context,
+									utils._if(
+										#context_highlight_list > 0,
+										utils.get_from_list(context_highlight_list, i),
+										context_highlight
+									),
+									utils._if(
+										#char_highlight_list > 0,
+										utils.get_from_list(char_highlight_list, i),
+										char_highlight
+									)
+								)
+							}
+						)
+					else
+						table.insert(
+							virtual_text,
+							{
+								g:indent_blankline_char_middle,
+								utils._if(
+									context,
+									utils._if(
+										#context_highlight_list > 0,
+										utils.get_from_list(context_highlight_list, i),
+										context_highlight
+									),
+									utils._if(
+										#char_highlight_list > 0,
+										utils.get_from_list(char_highlight_list, i),
+										char_highlight
+									)
+								)
+							}
+						)
+					end
+				end
+			-- end char in indent:
+				if g:indent_blankline_char_end == ' ' then
+					table.insert(
+						virtual_text,
+						{
+							utils._if(
+								utils._if(blankline, space_char_blankline, space_char),
+								utils._if(
+									blankline,
+									utils._if(
+										#space_char_blankline_highlight_list > 0,
+										utils.get_from_list(space_char_blankline_highlight_list, i),
+										space_char_blankline_highlight
+									),
+									utils._if(
+										#space_char_highlight_list > 0,
+										utils.get_from_list(space_char_highlight_list, i),
+										space_char_highlight
+									)
+								)
+							)
+						}
+					)
+				elseif g:indent_blankline_char_end == '|' then
+					table.insert(
+						virtual_text,
+						{
+							utils._if(
+								#char_list > 0,
+								utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
+								char
+							),
+							utils._if(
+								context,
+								utils._if(
+									#context_highlight_list > 0,
+									utils.get_from_list(context_highlight_list, i),
+									context_highlight
+								),
+								utils._if(
+									#char_highlight_list > 0,
+									utils.get_from_list(char_highlight_list, i),
+									char_highlight
+								)
+							)
+						}
+					)
+				else
+					table.insert(
+						virtual_text,
+						{
+							g:indent_blankline_char_end,
+							utils._if(
+								context,
+								utils._if(
+									#context_highlight_list > 0,
+									utils.get_from_list(context_highlight_list, i),
+									context_highlight
+								),
+								utils._if(
+									#char_highlight_list > 0,
+									utils.get_from_list(char_highlight_list, i),
+									char_highlight
+								)
+							)
+						}
+					)
+				end
         end
 
         if ((blankline and trail_indent) or extra) and (first_indent or #virtual_text > 0) then

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -68,37 +68,95 @@ local refresh = function()
     local get_virtual_text = function(indent, extra, blankline, context_active, context_indent)
         local virtual_text = {}
         -- first indent:
-
+		--note: i am temporarily setting the first indent with the others
         for i = 1, math.min(math.max(indent, 0), max_indent_level) do
             local context = context_active and context_indent == i
             -- first char in indent:
-                table.insert(
-                    virtual_text,
-                    {
-                        utils._if(
-                            i == 1 and blankline and end_of_line and #end_of_line_char > 0,
-                            end_of_line_char,
+				if( i == 1 and blankline and end_of_line and #end_of_line_char > 0 ) then
+					table.insert(
+						virtual_text,
+						{
+							end_of_line_char,
+							utils._if(
+								context,
+								utils._if(
+									#context_highlight_list > 0,
+									utils.get_from_list(context_highlight_list, i),
+									context_highlight
+								),
+								utils._if(
+									#char_highlight_list > 0,
+									utils.get_from_list(char_highlight_list, i),
+									char_highlight
+								)
+							)
+						}
+					)
+				elseif vim.g.indent_blankline_char_first == " " then
+                    table.insert(
+                        virtual_text,
+                        {
+                            utils._if(blankline, space_char_blankline, space_char):rep(space-2),
+                            utils._if(
+                                blankline,
+                                utils._if(
+                                    #space_char_blankline_highlight_list > 0,
+                                    utils.get_from_list(space_char_blankline_highlight_list, i),
+                                    space_char_blankline_highlight
+                                ),
+                                utils._if(
+                                    #space_char_highlight_list > 0,
+                                    utils.get_from_list(space_char_highlight_list, i),
+                                    space_char_highlight
+                                )
+                            )
+                        }
+                    )
+                elseif vim.g.indent_blankline_char_first == "|" then
+                    table.insert(
+                        virtual_text,
+                        {
                             utils._if(
                                 #char_list > 0,
                                 utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
                                 char
-                            )
-                        ),
-                        utils._if(
-                            context,
+                            ):rep(space-2),
                             utils._if(
-                                #context_highlight_list > 0,
-                                utils.get_from_list(context_highlight_list, i),
-                                context_highlight
-                            ),
-                            utils._if(
-                                #char_highlight_list > 0,
-                                utils.get_from_list(char_highlight_list, i),
-                                char_highlight
+                                context,
+                                utils._if(
+                                    #context_highlight_list > 0,
+                                    utils.get_from_list(context_highlight_list, i),
+                                    context_highlight
+                                ),
+                                utils._if(
+                                    #char_highlight_list > 0,
+                                    utils.get_from_list(char_highlight_list, i),
+                                    char_highlight
+                                )
                             )
-                        )
-                    }
-                )
+                        }
+                    )
+                else
+                    table.insert(
+                        virtual_text,
+                        {
+                            utils._if(1, vim.g.indent_blankline_char_first, 0):rep(space-2),
+                            utils._if(
+                                context,
+                                utils._if(
+                                    #context_highlight_list > 0,
+                                    utils.get_from_list(context_highlight_list, i),
+                                    context_highlight
+                                ),
+                                utils._if(
+                                    #char_highlight_list > 0,
+                                    utils.get_from_list(char_highlight_list, i),
+                                    char_highlight
+                                )
+                            )
+                        }
+                    )
+                end
             -- middle char in indent:
                 if vim.g.indent_blankline_char_middle == " " then
                     table.insert(

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -139,9 +139,7 @@ local refresh = function()
 
     local get_virtual_text = function(indent, extra, blankline, context_active, context_indent)
         local virtual_text = {}
-        -- first indent:
-        --note: i am temporarily setting the first indent with the others
-        for i = 1, math.min(math.max(indent, 0), max_indent_level) do
+        for i = utils.if(first_indent, 1, 2), math.min(math.max(indent, 0), max_indent_level) do
             local context = context_active and context_indent == i
             -- first char in indent:
                 if( i == 1 and blankline and end_of_line and #end_of_line_char > 0 ) then

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -42,6 +42,9 @@ local refresh = function()
     local char = vim.g.indent_blankline_char
     local char_list = vim.g.indent_blankline_char_list
     local char_highlight_list = vim.g.indent_blankline_char_highlight_list
+    local char_first = vim.g.indent_blankline_char_first
+    local char_middle = vim.g.indent_blankline_char_middle
+    local char_end = vim.g.indent_blankline_char_end
     local space_char_highlight_list = vim.g.indent_blankline_space_char_highlight_list
     local space_char_blankline_highlight_list = vim.g.indent_blankline_space_char_blankline_highlight_list
     local space_char = vim.g.indent_blankline_space_char
@@ -92,7 +95,7 @@ local refresh = function()
 							)
 						}
 					)
-				elseif vim.g.indent_blankline_char_first == " " then
+				elseif char_first == " " then
                     table.insert(
                         virtual_text,
                         {
@@ -112,7 +115,7 @@ local refresh = function()
                             )
                         }
                     )
-                elseif vim.g.indent_blankline_char_first == "|" then
+                elseif char_first == "|" then
                     table.insert(
                         virtual_text,
                         {
@@ -140,7 +143,7 @@ local refresh = function()
                     table.insert(
                         virtual_text,
                         {
-                            utils._if(1, vim.g.indent_blankline_char_first, 0),
+                            char_first,
                             utils._if(
                                 context,
                                 utils._if(
@@ -158,7 +161,7 @@ local refresh = function()
                     )
                 end
             -- middle char in indent:
-                if vim.g.indent_blankline_char_middle == " " then
+                if char_middle == " " then
                     table.insert(
                         virtual_text,
                         {
@@ -178,7 +181,7 @@ local refresh = function()
                             )
                         }
                     )
-                elseif vim.g.indent_blankline_char_middle == "|" then
+                elseif char_middle == "|" then
                     table.insert(
                         virtual_text,
                         {
@@ -206,7 +209,7 @@ local refresh = function()
                     table.insert(
                         virtual_text,
                         {
-                            utils._if(1, vim.g.indent_blankline_char_middle, 0):rep(space-2),
+                            utils._if(1, char_middle, 0):rep(space-2),
                             utils._if(
                                 context,
                                 utils._if(
@@ -224,7 +227,7 @@ local refresh = function()
                     )
                 end
             -- end char in indent:
-                if vim.g.indent_blankline_char_end == " " then
+                if char_end == " " then
                     table.insert(
                         virtual_text,
                         {
@@ -244,7 +247,7 @@ local refresh = function()
                             )
                         }
                     )
-                elseif vim.g.indent_blankline_char_end == "|" then
+                elseif char_end == "|" then
                     table.insert(
                         virtual_text,
                         {
@@ -272,7 +275,7 @@ local refresh = function()
                     table.insert(
                         virtual_text,
                         {
-                            utils._if(1, vim.g.indent_blankline_char_end, 0),
+                            char_end,
                             utils._if(
                                 context,
                                 utils._if(

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -68,7 +68,7 @@ local refresh = function()
         context_status, context_start, context_end = utils.get_current_context(vim.g.indent_blankline_context_patterns)
     end
 
-	local insert_char_of_indent = function( virtual_text, current_char, current_indent_level repetitons )
+	local insert_char_of_indent = function( virtual_text, current_char, current_indent_level, repetitons )
 		if current_char == " " then
 			table.insert(
 				virtual_text,

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -68,7 +68,7 @@ local refresh = function()
         context_status, context_start, context_end = utils.get_current_context(vim.g.indent_blankline_context_patterns)
     end
 
-	local insert_char_of_indent = function( virtual_text, current_char, repetitons )
+	local insert_char_of_indent = function( virtual_text, current_char, current_indent_level repetitons )
 		if current_char == " " then
 			table.insert(
 				virtual_text,
@@ -78,12 +78,12 @@ local refresh = function()
 						blankline,
 						utils._if(
 							#space_char_blankline_highlight_list > 0,
-								utils.get_from_list(space_char_blankline_highlight_list, i),
+								utils.get_from_list(space_char_blankline_highlight_list, current_indent_level),
 								space_char_blankline_highlight
 						),
 						utils._if(
 							#space_char_highlight_list > 0,
-							utils.get_from_list(space_char_highlight_list, i),
+							utils.get_from_list(space_char_highlight_list, current_indent_level),
 							space_char_highlight
 						)
 					)
@@ -95,19 +95,19 @@ local refresh = function()
 				{
 					utils._if(
 						#char_list > 0,
-						utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
+						utils.get_from_list(char_list, current_indent_level - utils._if(not first_indent, 1, 0)),
 						char
 					):rep(repetitons),
 					utils._if(
 						context,
 						utils._if(
 							#context_highlight_list > 0,
-							utils.get_from_list(context_highlight_list, i),
+							utils.get_from_list(context_highlight_list, current_indent_level),
 							context_highlight
 						),
 						utils._if(
 							#char_highlight_list > 0,
-							utils.get_from_list(char_highlight_list, i),
+							utils.get_from_list(char_highlight_list, current_indent_level),
 							char_highlight
 						)
 					)
@@ -117,18 +117,18 @@ local refresh = function()
 			table.insert(
 				virtual_text,
 				{
---					utils._if(1, current_char, 0):rep(repetitons),
+					--utils._if(1, current_char, 0):rep(repetitons),
 					current_char:rep(repetitons),
 					utils._if(
 						context,
 						utils._if(
 							#context_highlight_list > 0,
-							utils.get_from_list(context_highlight_list, i),
+							utils.get_from_list(context_highlight_list, current_indent_level),
 							context_highlight
 						),
 						utils._if(
 							#char_highlight_list > 0,
-							utils.get_from_list(char_highlight_list, i),
+							utils.get_from_list(char_highlight_list, current_indent_level),
 							char_highlight
 						)
 					)
@@ -165,12 +165,12 @@ local refresh = function()
 						}
 					)
 				else
-					insert_char_of_indent( virtual_text, char_first, 1 )
+					insert_char_of_indent( virtual_text, char_first, i, 1 )
                 end
             -- middle char in indent:
-				insert_char_of_indent( virtual_text, char_middle, space-2 )
+				insert_char_of_indent( virtual_text, char_middle, i, space-2 )
             -- end char in indent:
-				insert_char_of_indent( virtual_text, char_end, 1 )
+				insert_char_of_indent( virtual_text, char_end, i, 1 )
         end
 		
  --       if ((blankline and trail_indent) or extra) and (first_indent or #virtual_text > 0) then

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -175,7 +175,7 @@ local refresh = function()
                 end
         end
         
-        if ((blankline and trail_indent) or extra) and (first_indent or #virtual_text > 0) then
+        if ((blankline or extra) and trail_indent) and (first_indent or #virtual_text > 0) then
             local index = math.ceil(#virtual_text / 2) + 1
             table.insert(
                 virtual_text,

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -177,32 +177,32 @@ local refresh = function()
                 end
         end
         
- --       if ((blankline and trail_indent) or extra) and (first_indent or #virtual_text > 0) then
- --           local index = math.ceil(#virtual_text / 2) + 1
- --           table.insert(
- --               virtual_text,
- --               {
- --                   utils._if(
- --                       #char_list > 0,
- --                       utils.get_from_list(char_list, index - utils._if(not first_indent, 1, 0)),
- --                       char
- --                   ),
- --                   utils._if(
- --                       context_active and context_indent == index,
- --                       utils._if(
- --                           #context_highlight_list > 0,
- --                           utils.get_from_list(context_highlight_list, index),
- --                           context_highlight
- --                       ),
- --                       utils._if(
- --                           #char_highlight_list > 0,
- --                           utils.get_from_list(char_highlight_list, index),
- --                           char_highlight
- --                       )
- --                   )
- --               }
- --           )
- --       end
+        if ((blankline and trail_indent) or extra) and (first_indent or #virtual_text > 0) then
+            local index = math.ceil(#virtual_text / 2) + 1
+            table.insert(
+                virtual_text,
+                {
+                    utils._if(
+                        #char_list > 0,
+                        utils.get_from_list(char_list, index - utils._if(not first_indent, 1, 0)),
+                        char
+                    ),
+                    utils._if(
+                        context_active and context_indent == index,
+                        utils._if(
+                            #context_highlight_list > 0,
+                            utils.get_from_list(context_highlight_list, index),
+                            context_highlight
+                        ),
+                        utils._if(
+                            #char_highlight_list > 0,
+                            utils.get_from_list(char_highlight_list, index),
+                            char_highlight
+                        )
+                    )
+                }
+            )
+        end
 
         return virtual_text
     end

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -164,13 +164,17 @@ local refresh = function()
 							)
 						}
 					)
-				else
+				elseif( char_end == '' or space > 1 ) then
 					insert_char_of_indent( virtual_text, char_first, i, 1 )
                 end
             -- middle char in indent:
 				insert_char_of_indent( virtual_text, char_middle, i, space-2 )
             -- end char in indent:
-				insert_char_of_indent( virtual_text, char_end, i, 1 )
+				if( char_end == '' ) then
+					insert_char_of_indent( virtual_text, char_middle, i, 1 )
+				else
+					insert_char_of_indent( virtual_text, char_end, i, 1 )
+				end
         end
 		
  --       if ((blankline and trail_indent) or extra) and (first_indent or #virtual_text > 0) then

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -67,176 +67,170 @@ local refresh = function()
 
     local get_virtual_text = function(indent, extra, blankline, context_active, context_indent)
         local virtual_text = {}
-		-- first indent:
+        -- first indent:
 
         for i = 2, math.min(math.max(indent, 0), max_indent_level) do
             local context = context_active and context_indent == i
-			-- first char in indent:
-				table.insert(
-					virtual_text,
-					{
-						utils._if(
-							i == 1 and blankline and end_of_line and #end_of_line_char > 0,
-							end_of_line_char,
-							utils._if(
-								#char_list > 0,
-								utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
-								char
-							)
-						),
-						utils._if(
-							context,
-							utils._if(
-								#context_highlight_list > 0,
-								utils.get_from_list(context_highlight_list, i),
-								context_highlight
-							),
-							utils._if(
-								#char_highlight_list > 0,
-								utils.get_from_list(char_highlight_list, i),
-								char_highlight
-							)
-						)
-					}
-				)
-			-- middle char in indent:
-				for space_count = 2, space-1 do
-					if g:indent_blankline_char_middle == ' ' then
-						table.insert(
-							virtual_text,
-							{
-								utils._if(
-									utils._if(blankline, space_char_blankline, space_char),
-									utils._if(
-										blankline,
-										utils._if(
-											#space_char_blankline_highlight_list > 0,
-											utils.get_from_list(space_char_blankline_highlight_list, i),
-											space_char_blankline_highlight
-										),
-										utils._if(
-											#space_char_highlight_list > 0,
-											utils.get_from_list(space_char_highlight_list, i),
-											space_char_highlight
-										)
-									)
-								)
-							}
-						)
-					elseif g:indent_blankline_char_middle == '|' then
-						table.insert(
-							virtual_text,
-							{
-								utils._if(
-									#char_list > 0,
-									utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
-									char
-								),
-								utils._if(
-									context,
-									utils._if(
-										#context_highlight_list > 0,
-										utils.get_from_list(context_highlight_list, i),
-										context_highlight
-									),
-									utils._if(
-										#char_highlight_list > 0,
-										utils.get_from_list(char_highlight_list, i),
-										char_highlight
-									)
-								)
-							}
-						)
-					else
-						table.insert(
-							virtual_text,
-							{
-								g:indent_blankline_char_middle,
-								utils._if(
-									context,
-									utils._if(
-										#context_highlight_list > 0,
-										utils.get_from_list(context_highlight_list, i),
-										context_highlight
-									),
-									utils._if(
-										#char_highlight_list > 0,
-										utils.get_from_list(char_highlight_list, i),
-										char_highlight
-									)
-								)
-							}
-						)
-					end
-				end
-			-- end char in indent:
-				if g:indent_blankline_char_end == ' ' then
-					table.insert(
-						virtual_text,
-						{
-							utils._if(
-								utils._if(blankline, space_char_blankline, space_char),
-								utils._if(
-									blankline,
-									utils._if(
-										#space_char_blankline_highlight_list > 0,
-										utils.get_from_list(space_char_blankline_highlight_list, i),
-										space_char_blankline_highlight
-									),
-									utils._if(
-										#space_char_highlight_list > 0,
-										utils.get_from_list(space_char_highlight_list, i),
-										space_char_highlight
-									)
-								)
-							)
-						}
-					)
-				elseif g:indent_blankline_char_end == '|' then
-					table.insert(
-						virtual_text,
-						{
-							utils._if(
-								#char_list > 0,
-								utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
-								char
-							),
-							utils._if(
-								context,
-								utils._if(
-									#context_highlight_list > 0,
-									utils.get_from_list(context_highlight_list, i),
-									context_highlight
-								),
-								utils._if(
-									#char_highlight_list > 0,
-									utils.get_from_list(char_highlight_list, i),
-									char_highlight
-								)
-							)
-						}
-					)
-				else
-					table.insert(
-						virtual_text,
-						{
-							g:indent_blankline_char_end,
-							utils._if(
-								context,
-								utils._if(
-									#context_highlight_list > 0,
-									utils.get_from_list(context_highlight_list, i),
-									context_highlight
-								),
-								utils._if(
-									#char_highlight_list > 0,
-									utils.get_from_list(char_highlight_list, i),
-									char_highlight
-								)
-							)
-						}
-					)
-				end
+            -- first char in indent:
+                table.insert(
+                    virtual_text,
+                    {
+                        utils._if(
+                            i == 1 and blankline and end_of_line and #end_of_line_char > 0,
+                            end_of_line_char,
+                            utils._if(
+                                #char_list > 0,
+                                utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
+                                char
+                            )
+                        ),
+                        utils._if(
+                            context,
+                            utils._if(
+                                #context_highlight_list > 0,
+                                utils.get_from_list(context_highlight_list, i),
+                                context_highlight
+                            ),
+                            utils._if(
+                                #char_highlight_list > 0,
+                                utils.get_from_list(char_highlight_list, i),
+                                char_highlight
+                            )
+                        )
+                    }
+                )
+            -- middle char in indent:
+                if g:indent_blankline_char_middle == ' ' then
+                    table.insert(
+                        virtual_text,
+                        {
+                            utils._if(blankline, space_char_blankline, space_char):rep(space-2),
+                            utils._if(
+                                blankline,
+                                utils._if(
+                                    #space_char_blankline_highlight_list > 0,
+                                    utils.get_from_list(space_char_blankline_highlight_list, i),
+                                    space_char_blankline_highlight
+                                ),
+                                utils._if(
+                                    #space_char_highlight_list > 0,
+                                    utils.get_from_list(space_char_highlight_list, i),
+                                    space_char_highlight
+                                )
+                            )
+                        }
+                    )
+                elseif g:indent_blankline_char_middle == '|' then
+                    table.insert(
+                        virtual_text,
+                        {
+                            utils._if(
+                                #char_list > 0,
+                                utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
+                                char
+                            ):rep(space-2),
+                            utils._if(
+                                context,
+                                utils._if(
+                                    #context_highlight_list > 0,
+                                    utils.get_from_list(context_highlight_list, i),
+                                    context_highlight
+                                ),
+                                utils._if(
+                                    #char_highlight_list > 0,
+                                    utils.get_from_list(char_highlight_list, i),
+                                    char_highlight
+                                )
+                            )
+                        }
+                    )
+                else
+                    table.insert(
+                        virtual_text,
+                        {
+                            utils._if(1, g:indent_blankline_char_middle, 0):rep(space-2),
+                            utils._if(
+                                context,
+                                utils._if(
+                                    #context_highlight_list > 0,
+                                    utils.get_from_list(context_highlight_list, i),
+                                    context_highlight
+                                ),
+                                utils._if(
+                                    #char_highlight_list > 0,
+                                    utils.get_from_list(char_highlight_list, i),
+                                    char_highlight
+                                )
+                            )
+                        }
+                    )
+                end
+            -- end char in indent:
+                if g:indent_blankline_char_end == ' ' then
+                    table.insert(
+                        virtual_text,
+                        {
+                            utils._if(blankline, space_char_blankline, space_char):rep(space-2),
+                            utils._if(
+                                blankline,
+                                utils._if(
+                                    #space_char_blankline_highlight_list > 0,
+                                    utils.get_from_list(space_char_blankline_highlight_list, i),
+                                    space_char_blankline_highlight
+                                ),
+                                utils._if(
+                                    #space_char_highlight_list > 0,
+                                    utils.get_from_list(space_char_highlight_list, i),
+                                    space_char_highlight
+                                )
+                            )
+                        }
+                    )
+                elseif g:indent_blankline_char_end == '|' then
+                    table.insert(
+                        virtual_text,
+                        {
+                            utils._if(
+                                #char_list > 0,
+                                utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
+                                char
+                            ):rep(space-2),
+                            utils._if(
+                                context,
+                                utils._if(
+                                    #context_highlight_list > 0,
+                                    utils.get_from_list(context_highlight_list, i),
+                                    context_highlight
+                                ),
+                                utils._if(
+                                    #char_highlight_list > 0,
+                                    utils.get_from_list(char_highlight_list, i),
+                                    char_highlight
+                                )
+                            )
+                        }
+                    )
+                else
+                    table.insert(
+                        virtual_text,
+                        {
+                            utils._if(1, g:indent_blankline_char_end, 0):rep(space-2),
+                            utils._if(
+                                context,
+                                utils._if(
+                                    #context_highlight_list > 0,
+                                    utils.get_from_list(context_highlight_list, i),
+                                    context_highlight
+                                ),
+                                utils._if(
+                                    #char_highlight_list > 0,
+                                    utils.get_from_list(char_highlight_list, i),
+                                    char_highlight
+                                )
+                            )
+                        }
+                    )
+                end
         end
 
         if ((blankline and trail_indent) or extra) and (first_indent or #virtual_text > 0) then

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -68,115 +68,115 @@ local refresh = function()
         context_status, context_start, context_end = utils.get_current_context(vim.g.indent_blankline_context_patterns)
     end
 
-	local insert_char_of_indent = function( virtual_text, current_char, current_indent_level, repetitons )
-		if current_char == " " then
-			table.insert(
-				virtual_text,
-				{
-					utils._if(blankline, space_char_blankline, space_char):rep(repetitons),
-					utils._if(
-						blankline,
-						utils._if(
-							#space_char_blankline_highlight_list > 0,
-								utils.get_from_list(space_char_blankline_highlight_list, current_indent_level),
-								space_char_blankline_highlight
-						),
-						utils._if(
-							#space_char_highlight_list > 0,
-							utils.get_from_list(space_char_highlight_list, current_indent_level),
-							space_char_highlight
-						)
-					)
-				}
-			)
-		elseif current_char == "|" then
-			table.insert(
-				virtual_text,
-				{
-					utils._if(
-						#char_list > 0,
-						utils.get_from_list(char_list, current_indent_level - utils._if(not first_indent, 1, 0)),
-						char
-					):rep(repetitons),
-					utils._if(
-						context,
-						utils._if(
-							#context_highlight_list > 0,
-							utils.get_from_list(context_highlight_list, current_indent_level),
-							context_highlight
-						),
-						utils._if(
-							#char_highlight_list > 0,
-							utils.get_from_list(char_highlight_list, current_indent_level),
-							char_highlight
-						)
-					)
-				}
-			)
-		else
-			table.insert(
-				virtual_text,
-				{
-					--utils._if(1, current_char, 0):rep(repetitons),
-					current_char:rep(repetitons),
-					utils._if(
-						context,
-						utils._if(
-							#context_highlight_list > 0,
-							utils.get_from_list(context_highlight_list, current_indent_level),
-							context_highlight
-						),
-						utils._if(
-							#char_highlight_list > 0,
-							utils.get_from_list(char_highlight_list, current_indent_level),
-							char_highlight
-						)
-					)
-				}
-			)
-		end
-	end
+    local insert_char_of_indent = function( virtual_text, current_char, current_indent_level, repetitons )
+        if current_char == " " then
+            table.insert(
+                virtual_text,
+                {
+                    utils._if(blankline, space_char_blankline, space_char):rep(repetitons),
+                    utils._if(
+                        blankline,
+                        utils._if(
+                            #space_char_blankline_highlight_list > 0,
+                                utils.get_from_list(space_char_blankline_highlight_list, current_indent_level),
+                                space_char_blankline_highlight
+                        ),
+                        utils._if(
+                            #space_char_highlight_list > 0,
+                            utils.get_from_list(space_char_highlight_list, current_indent_level),
+                            space_char_highlight
+                        )
+                    )
+                }
+            )
+        elseif current_char == "|" then
+            table.insert(
+                virtual_text,
+                {
+                    utils._if(
+                        #char_list > 0,
+                        utils.get_from_list(char_list, current_indent_level - utils._if(not first_indent, 1, 0)),
+                        char
+                    ):rep(repetitons),
+                    utils._if(
+                        context,
+                        utils._if(
+                            #context_highlight_list > 0,
+                            utils.get_from_list(context_highlight_list, current_indent_level),
+                            context_highlight
+                        ),
+                        utils._if(
+                            #char_highlight_list > 0,
+                            utils.get_from_list(char_highlight_list, current_indent_level),
+                            char_highlight
+                        )
+                    )
+                }
+            )
+        else
+            table.insert(
+                virtual_text,
+                {
+                    --utils._if(1, current_char, 0):rep(repetitons),
+                    current_char:rep(repetitons),
+                    utils._if(
+                        context,
+                        utils._if(
+                            #context_highlight_list > 0,
+                            utils.get_from_list(context_highlight_list, current_indent_level),
+                            context_highlight
+                        ),
+                        utils._if(
+                            #char_highlight_list > 0,
+                            utils.get_from_list(char_highlight_list, current_indent_level),
+                            char_highlight
+                        )
+                    )
+                }
+            )
+        end
+    end
 
     local get_virtual_text = function(indent, extra, blankline, context_active, context_indent)
         local virtual_text = {}
         -- first indent:
-		--note: i am temporarily setting the first indent with the others
+        --note: i am temporarily setting the first indent with the others
         for i = 1, math.min(math.max(indent, 0), max_indent_level) do
             local context = context_active and context_indent == i
             -- first char in indent:
-				if( i == 1 and blankline and end_of_line and #end_of_line_char > 0 ) then
-					table.insert(
-						virtual_text,
-						{
-							end_of_line_char,
-							utils._if(
-								context,
-								utils._if(
-									#context_highlight_list > 0,
-									utils.get_from_list(context_highlight_list, i),
-									context_highlight
-								),
-								utils._if(
-									#char_highlight_list > 0,
-									utils.get_from_list(char_highlight_list, i),
-									char_highlight
-								)
-							)
-						}
-					)
-				elseif( char_end == '' or space > 1 ) then
-					insert_char_of_indent( virtual_text, char_first, i, 1 )
+                if( i == 1 and blankline and end_of_line and #end_of_line_char > 0 ) then
+                    table.insert(
+                        virtual_text,
+                        {
+                            end_of_line_char,
+                            utils._if(
+                                context,
+                                utils._if(
+                                    #context_highlight_list > 0,
+                                    utils.get_from_list(context_highlight_list, i),
+                                    context_highlight
+                                ),
+                                utils._if(
+                                    #char_highlight_list > 0,
+                                    utils.get_from_list(char_highlight_list, i),
+                                    char_highlight
+                                )
+                            )
+                        }
+                    )
+                elseif( char_end == '' or space > 1 ) then
+                    insert_char_of_indent( virtual_text, char_first, i, 1 )
                 end
             -- middle char in indent:
-				insert_char_of_indent( virtual_text, char_middle, i, space-2 )
+                insert_char_of_indent( virtual_text, char_middle, i, space-2 )
             -- end char in indent:
-				if( char_end == '' ) then
-					insert_char_of_indent( virtual_text, char_middle, i, 1 )
-				else
-					insert_char_of_indent( virtual_text, char_end, i, 1 )
-				end
+                if( char_end == '' ) then
+                    insert_char_of_indent( virtual_text, char_middle, i, 1 )
+                else
+                    insert_char_of_indent( virtual_text, char_end, i, 1 )
+                end
         end
-		
+        
  --       if ((blankline and trail_indent) or extra) and (first_indent or #virtual_text > 0) then
  --           local index = math.ceil(#virtual_text / 2) + 1
  --           table.insert(

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -69,7 +69,7 @@ local refresh = function()
         local virtual_text = {}
         -- first indent:
 
-        for i = 2, math.min(math.max(indent, 0), max_indent_level) do
+        for i = 1, math.min(math.max(indent, 0), max_indent_level) do
             local context = context_active and context_indent == i
             -- first char in indent:
                 table.insert(

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -170,7 +170,7 @@ local refresh = function()
                     table.insert(
                         virtual_text,
                         {
-                            utils._if(blankline, space_char_blankline, space_char):rep(space-2),
+                            utils._if(blankline, space_char_blankline, space_char),
                             utils._if(
                                 blankline,
                                 utils._if(
@@ -194,7 +194,7 @@ local refresh = function()
                                 #char_list > 0,
                                 utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
                                 char
-                            ):rep(space-2),
+                            ),
                             utils._if(
                                 context,
                                 utils._if(
@@ -214,7 +214,7 @@ local refresh = function()
                     table.insert(
                         virtual_text,
                         {
-                            utils._if(1, vim.g.indent_blankline_char_end, 0):rep(space-2),
+                            utils._if(1, vim.g.indent_blankline_char_end, 0),
                             utils._if(
                                 context,
                                 utils._if(

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -100,7 +100,7 @@ local refresh = function()
                     }
                 )
             -- middle char in indent:
-                if g:indent_blankline_char_middle == ' ' then
+                if vim.g.indent_blankline_char_middle == " " then
                     table.insert(
                         virtual_text,
                         {
@@ -120,7 +120,7 @@ local refresh = function()
                             )
                         }
                     )
-                elseif g:indent_blankline_char_middle == '|' then
+                elseif vim.g.indent_blankline_char_middle == "|" then
                     table.insert(
                         virtual_text,
                         {
@@ -148,7 +148,7 @@ local refresh = function()
                     table.insert(
                         virtual_text,
                         {
-                            utils._if(1, g:indent_blankline_char_middle, 0):rep(space-2),
+                            utils._if(1, vim.g.indent_blankline_char_middle, 0):rep(space-2),
                             utils._if(
                                 context,
                                 utils._if(
@@ -166,7 +166,7 @@ local refresh = function()
                     )
                 end
             -- end char in indent:
-                if g:indent_blankline_char_end == ' ' then
+                if vim.g.indent_blankline_char_end == " " then
                     table.insert(
                         virtual_text,
                         {
@@ -186,7 +186,7 @@ local refresh = function()
                             )
                         }
                     )
-                elseif g:indent_blankline_char_end == '|' then
+                elseif vim.g.indent_blankline_char_end == "|" then
                     table.insert(
                         virtual_text,
                         {
@@ -214,7 +214,7 @@ local refresh = function()
                     table.insert(
                         virtual_text,
                         {
-                            utils._if(1, g:indent_blankline_char_end, 0):rep(space-2),
+                            utils._if(1, vim.g.indent_blankline_char_end, 0):rep(space-2),
                             utils._if(
                                 context,
                                 utils._if(

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -290,33 +290,33 @@ local refresh = function()
                     )
                 end
         end
-
-        if ((blankline and trail_indent) or extra) and (first_indent or #virtual_text > 0) then
-            local index = math.ceil(#virtual_text / 2) + 1
-            table.insert(
-                virtual_text,
-                {
-                    utils._if(
-                        #char_list > 0,
-                        utils.get_from_list(char_list, index - utils._if(not first_indent, 1, 0)),
-                        char
-                    ),
-                    utils._if(
-                        context_active and context_indent == index,
-                        utils._if(
-                            #context_highlight_list > 0,
-                            utils.get_from_list(context_highlight_list, index),
-                            context_highlight
-                        ),
-                        utils._if(
-                            #char_highlight_list > 0,
-                            utils.get_from_list(char_highlight_list, index),
-                            char_highlight
-                        )
-                    )
-                }
-            )
-        end
+		
+ --       if ((blankline and trail_indent) or extra) and (first_indent or #virtual_text > 0) then
+ --           local index = math.ceil(#virtual_text / 2) + 1
+ --           table.insert(
+ --               virtual_text,
+ --               {
+ --                   utils._if(
+ --                       #char_list > 0,
+ --                       utils.get_from_list(char_list, index - utils._if(not first_indent, 1, 0)),
+ --                       char
+ --                   ),
+ --                   utils._if(
+ --                       context_active and context_indent == index,
+ --                       utils._if(
+ --                           #context_highlight_list > 0,
+ --                           utils.get_from_list(context_highlight_list, index),
+ --                           context_highlight
+ --                       ),
+ --                       utils._if(
+ --                           #char_highlight_list > 0,
+ --                           utils.get_from_list(char_highlight_list, index),
+ --                           char_highlight
+ --                       )
+ --                   )
+ --               }
+ --           )
+ --       end
 
         return virtual_text
     end

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -68,6 +68,75 @@ local refresh = function()
         context_status, context_start, context_end = utils.get_current_context(vim.g.indent_blankline_context_patterns)
     end
 
+	local insert_char_of_indent = function( virtual_text, current_char, repetitons )
+		if current_char == " " then
+			table.insert(
+				virtual_text,
+				{
+					utils._if(blankline, space_char_blankline, space_char):rep(repetitons),
+					utils._if(
+						blankline,
+						utils._if(
+							#space_char_blankline_highlight_list > 0,
+								utils.get_from_list(space_char_blankline_highlight_list, i),
+								space_char_blankline_highlight
+						),
+						utils._if(
+							#space_char_highlight_list > 0,
+							utils.get_from_list(space_char_highlight_list, i),
+							space_char_highlight
+						)
+					)
+				}
+			)
+		elseif current_char == "|" then
+			table.insert(
+				virtual_text,
+				{
+					utils._if(
+						#char_list > 0,
+						utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
+						char
+					):rep(repetitons),
+					utils._if(
+						context,
+						utils._if(
+							#context_highlight_list > 0,
+							utils.get_from_list(context_highlight_list, i),
+							context_highlight
+						),
+						utils._if(
+							#char_highlight_list > 0,
+							utils.get_from_list(char_highlight_list, i),
+							char_highlight
+						)
+					)
+				}
+			)
+		else
+			table.insert(
+				virtual_text,
+				{
+--					utils._if(1, current_char, 0):rep(repetitons),
+					current_char:rep(repetitons),
+					utils._if(
+						context,
+						utils._if(
+							#context_highlight_list > 0,
+							utils.get_from_list(context_highlight_list, i),
+							context_highlight
+						),
+						utils._if(
+							#char_highlight_list > 0,
+							utils.get_from_list(char_highlight_list, i),
+							char_highlight
+						)
+					)
+				}
+			)
+		end
+	end
+
     local get_virtual_text = function(indent, extra, blankline, context_active, context_indent)
         local virtual_text = {}
         -- first indent:
@@ -95,203 +164,13 @@ local refresh = function()
 							)
 						}
 					)
-				elseif char_first == " " then
-                    table.insert(
-                        virtual_text,
-                        {
-                            utils._if(blankline, space_char_blankline, space_char),
-                            utils._if(
-                                blankline,
-                                utils._if(
-                                    #space_char_blankline_highlight_list > 0,
-                                    utils.get_from_list(space_char_blankline_highlight_list, i),
-                                    space_char_blankline_highlight
-                                ),
-                                utils._if(
-                                    #space_char_highlight_list > 0,
-                                    utils.get_from_list(space_char_highlight_list, i),
-                                    space_char_highlight
-                                )
-                            )
-                        }
-                    )
-                elseif char_first == "|" then
-                    table.insert(
-                        virtual_text,
-                        {
-                            utils._if(
-                                #char_list > 0,
-                                utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
-                                char
-                            ),
-                            utils._if(
-                                context,
-                                utils._if(
-                                    #context_highlight_list > 0,
-                                    utils.get_from_list(context_highlight_list, i),
-                                    context_highlight
-                                ),
-                                utils._if(
-                                    #char_highlight_list > 0,
-                                    utils.get_from_list(char_highlight_list, i),
-                                    char_highlight
-                                )
-                            )
-                        }
-                    )
-                else
-                    table.insert(
-                        virtual_text,
-                        {
-                            char_first,
-                            utils._if(
-                                context,
-                                utils._if(
-                                    #context_highlight_list > 0,
-                                    utils.get_from_list(context_highlight_list, i),
-                                    context_highlight
-                                ),
-                                utils._if(
-                                    #char_highlight_list > 0,
-                                    utils.get_from_list(char_highlight_list, i),
-                                    char_highlight
-                                )
-                            )
-                        }
-                    )
+				else
+					insert_char_of_indent( virtual_text, char_first, 1 )
                 end
             -- middle char in indent:
-                if char_middle == " " then
-                    table.insert(
-                        virtual_text,
-                        {
-                            utils._if(blankline, space_char_blankline, space_char):rep(space-2),
-                            utils._if(
-                                blankline,
-                                utils._if(
-                                    #space_char_blankline_highlight_list > 0,
-                                    utils.get_from_list(space_char_blankline_highlight_list, i),
-                                    space_char_blankline_highlight
-                                ),
-                                utils._if(
-                                    #space_char_highlight_list > 0,
-                                    utils.get_from_list(space_char_highlight_list, i),
-                                    space_char_highlight
-                                )
-                            )
-                        }
-                    )
-                elseif char_middle == "|" then
-                    table.insert(
-                        virtual_text,
-                        {
-                            utils._if(
-                                #char_list > 0,
-                                utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
-                                char
-                            ):rep(space-2),
-                            utils._if(
-                                context,
-                                utils._if(
-                                    #context_highlight_list > 0,
-                                    utils.get_from_list(context_highlight_list, i),
-                                    context_highlight
-                                ),
-                                utils._if(
-                                    #char_highlight_list > 0,
-                                    utils.get_from_list(char_highlight_list, i),
-                                    char_highlight
-                                )
-                            )
-                        }
-                    )
-                else
-                    table.insert(
-                        virtual_text,
-                        {
-                            utils._if(1, char_middle, 0):rep(space-2),
-                            utils._if(
-                                context,
-                                utils._if(
-                                    #context_highlight_list > 0,
-                                    utils.get_from_list(context_highlight_list, i),
-                                    context_highlight
-                                ),
-                                utils._if(
-                                    #char_highlight_list > 0,
-                                    utils.get_from_list(char_highlight_list, i),
-                                    char_highlight
-                                )
-                            )
-                        }
-                    )
-                end
+				insert_char_of_indent( virtual_text, char_middle, space-2 )
             -- end char in indent:
-                if char_end == " " then
-                    table.insert(
-                        virtual_text,
-                        {
-                            utils._if(blankline, space_char_blankline, space_char),
-                            utils._if(
-                                blankline,
-                                utils._if(
-                                    #space_char_blankline_highlight_list > 0,
-                                    utils.get_from_list(space_char_blankline_highlight_list, i),
-                                    space_char_blankline_highlight
-                                ),
-                                utils._if(
-                                    #space_char_highlight_list > 0,
-                                    utils.get_from_list(space_char_highlight_list, i),
-                                    space_char_highlight
-                                )
-                            )
-                        }
-                    )
-                elseif char_end == "|" then
-                    table.insert(
-                        virtual_text,
-                        {
-                            utils._if(
-                                #char_list > 0,
-                                utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
-                                char
-                            ),
-                            utils._if(
-                                context,
-                                utils._if(
-                                    #context_highlight_list > 0,
-                                    utils.get_from_list(context_highlight_list, i),
-                                    context_highlight
-                                ),
-                                utils._if(
-                                    #char_highlight_list > 0,
-                                    utils.get_from_list(char_highlight_list, i),
-                                    char_highlight
-                                )
-                            )
-                        }
-                    )
-                else
-                    table.insert(
-                        virtual_text,
-                        {
-                            char_end,
-                            utils._if(
-                                context,
-                                utils._if(
-                                    #context_highlight_list > 0,
-                                    utils.get_from_list(context_highlight_list, i),
-                                    context_highlight
-                                ),
-                                utils._if(
-                                    #char_highlight_list > 0,
-                                    utils.get_from_list(char_highlight_list, i),
-                                    char_highlight
-                                )
-                            )
-                        }
-                    )
-                end
+				insert_char_of_indent( virtual_text, char_end, 1 )
         end
 		
  --       if ((blankline and trail_indent) or extra) and (first_indent or #virtual_text > 0) then

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -96,7 +96,7 @@ local refresh = function()
                     table.insert(
                         virtual_text,
                         {
-                            utils._if(blankline, space_char_blankline, space_char):rep(space-2),
+                            utils._if(blankline, space_char_blankline, space_char),
                             utils._if(
                                 blankline,
                                 utils._if(
@@ -120,7 +120,7 @@ local refresh = function()
                                 #char_list > 0,
                                 utils.get_from_list(char_list, i - utils._if(not first_indent, 1, 0)),
                                 char
-                            ):rep(space-2),
+                            ),
                             utils._if(
                                 context,
                                 utils._if(
@@ -140,7 +140,7 @@ local refresh = function()
                     table.insert(
                         virtual_text,
                         {
-                            utils._if(1, vim.g.indent_blankline_char_first, 0):rep(space-2),
+                            utils._if(1, vim.g.indent_blankline_char_first, 0),
                             utils._if(
                                 context,
                                 utils._if(

--- a/plugin/indent_blankline.vim
+++ b/plugin/indent_blankline.vim
@@ -7,6 +7,9 @@ let g:loaded_indent_blankline = 1
 let g:indent_blankline_char = get(g:, 'indent_blankline_char', get(g:, 'indentLine_char', '|'))
 let g:indent_blankline_char_list = get(g:, 'indent_blankline_char_list', get(g:, 'indentLine_char_list', []))
 let g:indent_blankline_char_highlight_list = get(g:, 'indent_blankline_char_highlight_list', [])
+let g:indent_blankline_char_first = get(g:, 'indent_blankline_char_first', '|')
+let g:indent_blankline_char_middle = get(g:, 'indent_blankline_char_middle', ' ')
+let g:indent_blankline_char_end = get(g:, 'indent_blankline_char_end', g:indent_blankline_char_middle)
 
 let g:indent_blankline_space_char = get(g:, 'indent_blankline_space_char', indent_blankline#helper#GetListChar('space', ' '))
 let g:indent_blankline_space_char_highlight_list = get(g:, 'indent_blankline_space_char_highlight_list', [])

--- a/plugin/indent_blankline.vim
+++ b/plugin/indent_blankline.vim
@@ -9,7 +9,7 @@ let g:indent_blankline_char_list = get(g:, 'indent_blankline_char_list', get(g:,
 let g:indent_blankline_char_highlight_list = get(g:, 'indent_blankline_char_highlight_list', [])
 let g:indent_blankline_char_first = get(g:, 'indent_blankline_char_first', '|')
 let g:indent_blankline_char_middle = get(g:, 'indent_blankline_char_middle', ' ')
-let g:indent_blankline_char_end = get(g:, 'indent_blankline_char_end', g:indent_blankline_char_middle)
+let g:indent_blankline_char_end = get(g:, 'indent_blankline_char_end', '')
 
 let g:indent_blankline_space_char = get(g:, 'indent_blankline_space_char', indent_blankline#helper#GetListChar('space', ' '))
 let g:indent_blankline_space_char_highlight_list = get(g:, 'indent_blankline_space_char_highlight_list', [])


### PR DESCRIPTION
This is a draft PR.
related to issue#74
With this, the user will be able to customize the appearance of the indent in a way similar to the tab in listchar in nvim.

new variables:
indent_blankline_char_first : (default is '|')
indent_blankline_char_middle : (default is ' ')
indent_blankline_char_end : (default is '')

These define the PATTERN the indent follows.

if char_end is empty then
> always put the char_first once
> put char_middle as many times to fill the tab length

if char_end in non empty then
> put char_first if more than one space is left in the tab length
> repeatedly put char_middle until only one space is left
> always put char_end

Note: the values of ' ' and '|' are special place holders. if ' ' is used then indent_blankline_char_space is inserted. and if '|' is used, then indent_blankline_char or indent_blankline_char_list is referred.
For any other char, the char itself is used.**

In the near future, the plan is to remove the dependency on these variables and use listchar itself. (thank you @lukas-reineke XD)



** I have implemented it in this way is because the user may have a char_list defined. Here, if the user uses '|', they would like that to represent a char from char_list. So I kept '|' as a placeholder for either the corresponding char from indent_blankline_char_list (if defined) or the default indent_blankline_char. 

The user may want to display ' ' itself. In this case, we can have '\ ' correspond to space[not implemented yet; but it should be easy to add]. Similarly '\|' can work with '|'.
 