### PR TITLE
bug: refresh on complete change

### DIFF
--- a/plugin/indent_blankline.vim
+++ b/plugin/indent_blankline.vim
@@ -32,7 +32,7 @@ lua require("indent_blankline").init()
 augroup IndentBlanklineAutogroup
     autocmd!
     autocmd OptionSet shiftwidth,tabstop,expandtab IndentBlanklineRefresh
-    autocmd FileChangedShellPost,TextChanged,TextChangedI,WinScrolled,BufWinEnter,Filetype * IndentBlanklineRefresh
+    autocmd FileChangedShellPost,TextChanged,TextChangedI,CompleteChanged,WinScrolled,BufWinEnter,Filetype * IndentBlanklineRefresh
     autocmd ColorScheme * lua require("indent_blankline.utils").reset_highlights()
 augroup END
 


### PR DESCRIPTION
Some completion engines re-indent the text while cycling through items.
This means text could get hidden behind the indent guides when the
indention becomes lower than when input started.

fix #166