### PR TITLE
bug: fix buftype exclude

### DIFF
--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -91,6 +91,8 @@ end
 
 local refresh = function()
     local v = utils.get_variable
+    local bufnr = vim.api.nvim_get_current_buf()
+
     if
         not utils.is_indent_blankline_enabled(
             vim.b.indent_blankline_enabled,
@@ -104,13 +106,15 @@ local refresh = function()
             vim.fn["bufname"]("")
         )
      then
+        if vim.b.__indent_blankline_active then
+            vim.schedule_wrap(utils.clear_buf_indent)(bufnr)
+        end
         vim.b.__indent_blankline_active = false
         return
     else
         vim.b.__indent_blankline_active = true
     end
 
-    local bufnr = vim.api.nvim_get_current_buf()
     local offset = math.max(vim.fn.line("w0") - 1 - v("indent_blankline_viewport_buffer"), 0)
     local left_offset = vim.fn.winsaveview().leftcol
     local range =

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -104,6 +104,10 @@ M.clear_line_indent = function(buf, lnum)
     xpcall(vim.api.nvim_buf_clear_namespace, M.error_handler, buf, vim.g.indent_blankline_namespace, lnum - 1, lnum)
 end
 
+M.clear_buf_indent = function(buf)
+    xpcall(vim.api.nvim_buf_clear_namespace, M.error_handler, buf, vim.g.indent_blankline_namespace, 0, -1)
+end
+
 M.get_from_list = function(list, i)
     return list[((i - 1) % #list) + 1]
 end


### PR DESCRIPTION
Clear the current buffer when `is_indent_blankline_enabled` switches from `true` to `false`.
Needs `schedule_wrap` because of some race condition when starting Neovim.

fix #175