### PR TITLE
Allow for display of listchars in indentation overlay. (refactor)

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -154,26 +154,12 @@ g:indent_blankline_char_highlight_list*g:indent_blankline_char_highlight_list*
         let g:indent_blankline_char_highlight_list = ['Error', 'Function']
 
 ------------------------------------------------------------------------------
-g:indent_blankline_space_char                  *g:indent_blankline_space_char*
-
-    Specifies the character to be used as the space value in between indent
-    lines.
-
-    Default: The listchars space value                                       ~
-
-    Example: >
-
-        let g:indent_blankline_space_char = ' '
-
-------------------------------------------------------------------------------
 g:indent_blankline_space_char_blankline*g:indent_blankline_space_char_blankline*
 
     Specifies the character to be used as the space value in between indent
     lines when the line is blank.
 
-    Also set by |g:indent_blankline_space_char|
-
-    Default: The listchars space value                                       ~
+    Default: An empty space character                                        ~
 
     Example: >
 
@@ -210,7 +196,6 @@ g:indent_blankline_space_char_blankline_highlight_list*g:indent_blankline_space_
         let g:indent_blankline_space_char_blankline_highlight_list = ['Error', 'Function']
 
 ------------------------------------------------------------------------------
-
 g:indent_blankline_use_treesitter          *g:indent_blankline_use_treesitter*
 
     Use treesitter to calculate indentation when possible.


### PR DESCRIPTION
My attempt at implementing #74. Now fully backwards compatible.


`set list listchars=tab:<->,space:⋅,trail:~,eol:↴`
Ligatures are handled by the terminal, not this plugin.
![image](https://user-images.githubusercontent.com/72616153/131563003-cf761d48-dbef-4691-9545-e06eb596d4bd.png)

The new behavior can be activated with `g:indent_blankline_show_whitespace`, which defaults to `false`. There won't be any change to existing behavior when updating without user intervention.
I also added several new variables (with documentation) to customize the appearance of the overlay text. They all default to their `listchars` values, or have appropriate fallbacks. 
```
g:indent_blankline_trail_char
g:indent_blankline_tab_char_start
g:indent_blankline_tab_char_fill
g:indent_blankline_tab_char_end
```