### PR TITLE
fix: clear hi of current line after moved to next

### DIFF
--- a/plugin/indent_blankline.vim
+++ b/plugin/indent_blankline.vim
@@ -32,7 +32,7 @@ lua require("indent_blankline").init()
 augroup IndentBlanklineAutogroup
     autocmd!
     autocmd OptionSet shiftwidth,tabstop,expandtab IndentBlanklineRefresh
-    autocmd FileChangedShellPost,TextChanged,TextChangedI,CompleteChanged,WinScrolled,BufWinEnter,Filetype * IndentBlanklineRefresh
+    autocmd FileChangedShellPost,TextChanged,TextChangedI,CompleteChanged,WinScrolled,BufWinEnter,Filetype,CursorMoved,CursorMovedI * IndentBlanklineRefresh
     autocmd ColorScheme * lua require("indent_blankline.utils").reset_highlights()
 augroup END
 


### PR DESCRIPTION
When scrolling down and up fast, it seems like it does not have time to refresh
![image](https://user-images.githubusercontent.com/10659110/131574030-efc21ff0-b165-4894-ad9b-c93e5d804d70.png)
