### PR TITLE
Version 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,13 @@ require("indent_blankline").setup {
 #### With custom `g:indent_blankline_char_highlight_list`
 
 ```lua
-vim.cmd [[highlight IndentBlanklineIndent1 guifg=#E06C75 guibg=NONE gui=NONE blend=nocombine]]
-vim.cmd [[highlight IndentBlanklineIndent2 guifg=#E5C07B guibg=NONE gui=NONE blend=nocombine]]
-vim.cmd [[highlight IndentBlanklineIndent3 guifg=#98C379 guibg=NONE gui=NONE blend=nocombine]]
-vim.cmd [[highlight IndentBlanklineIndent4 guifg=#56B6C2 guibg=NONE gui=NONE blend=nocombine]]
-vim.cmd [[highlight IndentBlanklineIndent5 guifg=#61AFEF guibg=NONE gui=NONE blend=nocombine]]
-vim.cmd [[highlight IndentBlanklineIndent6 guifg=#C678DD guibg=NONE gui=NONE blend=nocombine]]
+vim.opt.termguicolors = true
+vim.cmd [[highlight IndentBlanklineIndent1 guifg=#E06C75 blend=nocombine]]
+vim.cmd [[highlight IndentBlanklineIndent2 guifg=#E5C07B blend=nocombine]]
+vim.cmd [[highlight IndentBlanklineIndent3 guifg=#98C379 blend=nocombine]]
+vim.cmd [[highlight IndentBlanklineIndent4 guifg=#56B6C2 blend=nocombine]]
+vim.cmd [[highlight IndentBlanklineIndent5 guifg=#61AFEF blend=nocombine]]
+vim.cmd [[highlight IndentBlanklineIndent6 guifg=#C678DD blend=nocombine]]
 
 vim.opt.listchars = {
     space = "⋅",
@@ -120,8 +121,9 @@ require("indent_blankline").setup {
 #### With custom background highlight
 
 ```lua
-vim.cmd [[highlight IndentBlanklineIndent1 guifg=NONE guibg=#1f1f1f gui=NONE blend=nocombine]]
-vim.cmd [[highlight IndentBlanklineIndent2 guifg=NONE guibg=#1a1a1a gui=NONE blend=nocombine]]
+vim.opt.termguicolors = true
+vim.cmd [[highlight IndentBlanklineIndent1 guibg=#1f1f1f blend=nocombine]]
+vim.cmd [[highlight IndentBlanklineIndent2 guibg=#1a1a1a blend=nocombine]]
 
 require("indent_blankline").setup {
     char_highlight_list = {

--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -2,7 +2,7 @@
 
 
 Author: Lukas Reineke <lukas.reineke@protonmail.com>
-Version: 2.1.4
+Version: 2.2.0
 
 ==============================================================================
 CONTENTS                                                    *indent-blankline*
@@ -494,6 +494,13 @@ g:indent_blankline_debug                            *g:indent_blankline_debug*
 
 ==============================================================================
  6. CHANGELOG                                     *indent-blankline-changelog*
+
+2.2.0
+ * Correctly display listchars under the indent guides
+   Huge thanks to @Daxtorim
+ * Remove options:
+    `indent_blankline_space_char` - listchars is used to get the correct space
+    character
 
 2.1.4
  * Fix race condition in `is_indent_blankline_enabled`

--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -154,26 +154,12 @@ g:indent_blankline_char_highlight_list*g:indent_blankline_char_highlight_list*
         let g:indent_blankline_char_highlight_list = ['Error', 'Function']
 
 ------------------------------------------------------------------------------
-g:indent_blankline_space_char                  *g:indent_blankline_space_char*
-
-    Specifies the character to be used as the space value in between indent
-    lines.
-
-    Default: The listchars space value                                       ~
-
-    Example: >
-
-        let g:indent_blankline_space_char = ' '
-
-------------------------------------------------------------------------------
 g:indent_blankline_space_char_blankline*g:indent_blankline_space_char_blankline*
 
     Specifies the character to be used as the space value in between indent
     lines when the line is blank.
 
-    Also set by |g:indent_blankline_space_char|
-
-    Default: The listchars space value                                       ~
+    Default: An empty space character                                        ~
 
     Example: >
 
@@ -210,7 +196,6 @@ g:indent_blankline_space_char_blankline_highlight_list*g:indent_blankline_space_
         let g:indent_blankline_space_char_blankline_highlight_list = ['Error', 'Function']
 
 ------------------------------------------------------------------------------
-
 g:indent_blankline_use_treesitter          *g:indent_blankline_use_treesitter*
 
     Use treesitter to calculate indentation when possible.


### PR DESCRIPTION
* Correctly display listchars under the indent guides
  Huge thanks to @Daxtorim
* Remove options:
  `indent_blankline_space_char` - listchars is used to get the correct space character

fixes #74 