### PR TITLE
bug: fix first indent guide with no indent

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -2,7 +2,7 @@
 
 
 Author: Lukas Reineke <lukas.reineke@protonmail.com>
-Version: 2.1.4
+Version: 2.2.0
 
 ==============================================================================
 CONTENTS                                                    *indent-blankline*
@@ -494,6 +494,13 @@ g:indent_blankline_debug                            *g:indent_blankline_debug*
 
 ==============================================================================
  6. CHANGELOG                                     *indent-blankline-changelog*
+
+2.2.0
+ * Correctly display listchars under the indent guides
+   Huge thanks to @Daxtorim
+ * Remove options:
+    `indent_blankline_space_char` - listchars is used to get the correct space
+    character
 
 2.1.4
  * Fix race condition in `is_indent_blankline_enabled`

--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -2,7 +2,7 @@
 
 
 Author: Lukas Reineke <lukas.reineke@protonmail.com>
-Version: 2.2.0
+Version: 2.2.1
 
 ==============================================================================
 CONTENTS                                                    *indent-blankline*
@@ -494,6 +494,10 @@ g:indent_blankline_debug                            *g:indent_blankline_debug*
 
 ==============================================================================
  6. CHANGELOG                                     *indent-blankline-changelog*
+
+2.2.1
+ * Fix first indent on a line with whitespace less than the current shift
+   width
 
 2.2.0
  * Correctly display listchars under the indent guides

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -350,7 +350,7 @@ local refresh = function()
                         context_indent = (indent or 0) + 1
                     end
 
-                    if not indent or indent == 0 then
+                    if (not indent or indent == 0) and #virtual_string == 0 then
                         vim.schedule_wrap(utils.clear_line_indent)(bufnr, i + offset)
                         return async:close()
                     end


### PR DESCRIPTION
if the indentation on a line was less than the current shift width, the
first indent character did not show.