### PR TITLE
Allowing to remove all listchars but keep indentation guides with 'set list/nolist'.

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -288,15 +288,17 @@ g:indent_blankline_enabled                        *g:indent_blankline_enabled*
         let g:indent_blankline_enabled = v:false
 
 ------------------------------------------------------------------------------
-g:indent_blankline_respect_list              *g:indent_blankline_respect_list*
+g:indent_blankline_disable_with_nolist *g:indent_blankline_disable_with_nolist*
 
-    Automatically turns this plugin off when the 'list' option is off.
+    When true, automatically turns this plugin off when |nolist| is set.
+    When false, setting |nolist| will keep displaying indentation guides but
+    removes whitespace characters set by |listchars|.
 
     Default: v:false                                                         ~
 
     Example: >
 
-        let g:indent_blankline_enabled = v:true
+        let g:indent_blankline_disable_with_nolist = v:true
 
 ------------------------------------------------------------------------------
 g:indent_blankline_filetype                      *g:indent_blankline_filetype*

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -55,7 +55,7 @@ M.is_indent_blankline_enabled =
     function(
         b_enabled,
         g_enabled,
-        respect_list,
+        disable_with_nolist,
         opt_list,
         filetype,
         filetype_include,
@@ -70,7 +70,7 @@ M.is_indent_blankline_enabled =
         if g_enabled ~= true then
             return false
         end
-        if respect_list and not opt_list then
+        if disable_with_nolist and not opt_list then
             return false
         end
 


### PR DESCRIPTION
Addressing #195.

I renamed the option `g:indent_blankline_respect_list` to the more descriptive name `g:indent_blankline_disable_with_list`. 
1. If this option is set to true, setting `nolist` will essentially disable the plugin as was implemented in #201.
2. If this option is set to false (default), setting `nolist` will replace all `listchars` with empty spaces (like `nolist` without this plugin) but keep indentation guides.