### PR TITLE
feature: add context-pattern-highlight

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -436,6 +436,22 @@ g:indent_blankline_context_patterns      *g:indent_blankline_context_patterns*
         let g:indent_blankline_context_patterns = ['^if']
 
 ------------------------------------------------------------------------------
+g:indent_blankline_context_pattern_highlight*g:indent_blankline_context_pattern_highlight*
+
+    Specifies a map of patterns set in
+    |g:indent_blankline_context_patterns| to highlight groups.
+    When the current matching context pattern is in the map, the context
+    will be highlighted with the corresponding highlight group.
+
+    Only used when |g:indent_blankline_show_current_context| is active
+
+    Default: {}                                                              ~
+
+    Example: >
+
+        let g:indent_blankline_context_pattern_highlight = {'function': 'Function'}
+
+------------------------------------------------------------------------------
 g:indent_blankline_viewport_buffer        *g:indent_blankline_viewport_buffer*
 
     Sets the buffer of extra lines before and after the current viewport that

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -119,6 +119,11 @@ M.setup = function(options)
         vim.g.indent_blankline_context_patterns,
         { "class", "function", "method" }
     )
+    vim.g.indent_blankline_context_pattern_highlight = o(
+        options.context_pattern_highlight,
+        vim.g.indent_blankline_context_pattern_highlight,
+        {}
+    )
     vim.g.indent_blankline_strict_tabs = o(options.strict_tabs, vim.g.indent_blankline_strict_tabs, false)
 
     vim.g.indent_blankline_disable_warning_message = o(
@@ -236,9 +241,12 @@ local refresh = function()
     local shiftwidth = utils._if(tabs, utils._if(no_tab_character, 2, vim.bo.tabstop), vim.bo.shiftwidth)
 
     local context_highlight_list = v "indent_blankline_context_highlight_list"
-    local context_status, context_start, context_end = false, 0, 0
+    local context_pattern_highlight = v "indent_blankline_context_pattern_highlight"
+    local context_status, context_start, context_end, context_pattern = false, 0, 0, nil
     if v "indent_blankline_show_current_context" then
-        context_status, context_start, context_end = utils.get_current_context(v "indent_blankline_context_patterns")
+        context_status, context_start, context_end, context_pattern = utils.get_current_context(
+            v "indent_blankline_context_patterns"
+        )
     end
 
     local get_virtual_text =
@@ -267,9 +275,13 @@ local refresh = function()
                             utils._if(
                                 context,
                                 utils._if(
-                                    #context_highlight_list > 0,
-                                    utils.get_from_list(context_highlight_list, i),
-                                    context_highlight
+                                    context_pattern_highlight[context_pattern],
+                                    context_pattern_highlight[context_pattern],
+                                    utils._if(
+                                        #context_highlight_list > 0,
+                                        utils.get_from_list(context_highlight_list, i),
+                                        context_highlight
+                                    )
                                 ),
                                 utils._if(
                                     #char_highlight_list > 0,

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -186,7 +186,7 @@ M.get_current_context = function(type_patterns)
             if node_type:find(rgx) then
                 local node_start, _, node_end, _ = cursor_node:range()
                 if node_start ~= node_end then
-                    return true, node_start + 1, node_end + 1
+                    return true, node_start + 1, node_end + 1, rgx
                 end
                 node_start, node_end = nil, nil
             end


### PR DESCRIPTION
Adds `g:indent_blankline_context_pattern_highlight` option.
It specifies a map of patterns set in `g:indent_blankline_context_patterns` to highlight groups.
When the current matching context pattern is in the map, the context will be highlighted with the corresponding highlight group.

Empty by default

Thank you Gen.F for the idea :pray: 