### PR TITLE
bug: init on enter

### DIFF
--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -7,7 +7,9 @@ local space_char_blankline_highlight = "IndentBlanklineSpaceCharBlankline"
 local context_highlight = "IndentBlanklineContextChar"
 
 M.init = function()
-    vim.g.indent_blankline_namespace = vim.api.nvim_create_namespace "indent_blankline"
+    if not vim.g.indent_blankline_namespace then
+        vim.g.indent_blankline_namespace = vim.api.nvim_create_namespace "indent_blankline"
+    end
 
     utils.reset_highlights()
 

--- a/plugin/indent_blankline.vim
+++ b/plugin/indent_blankline.vim
@@ -34,5 +34,6 @@ augroup IndentBlanklineAutogroup
     autocmd OptionSet list,shiftwidth,tabstop,expandtab IndentBlanklineRefresh
     autocmd FileChangedShellPost,TextChanged,TextChangedI,CompleteChanged,WinScrolled,BufWinEnter,Filetype * IndentBlanklineRefresh
     autocmd ColorScheme * lua require("indent_blankline.utils").reset_highlights()
+    autocmd VimEnter * lua require("indent_blankline").init()
 augroup END
 


### PR DESCRIPTION
Run init on VimEnter to initialize indents in all open windows.
But also run init on plugin load, in case of lazy loading.