### PR TITLE
Version 2.6.2

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -2,7 +2,7 @@
 
 
 Author: Lukas Reineke <lukas.reineke@protonmail.com>
-Version: 2.6.1
+Version: 2.6.2
 
 ==============================================================================
 CONTENTS                                                    *indent-blankline*
@@ -536,6 +536,11 @@ g:indent_blankline_debug                            *g:indent_blankline_debug*
 
 ==============================================================================
  6. CHANGELOG                                     *indent-blankline-changelog*
+
+2.6.2
+ * Memoize the find indent function
+ * Run init on VimEnter to initialize indents in all open windows
+ * Run init on plugin load to work with lazy loading
 
 2.6.1
  * Wait until buffer is loaded before doing anything

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -7,7 +7,9 @@ local space_char_blankline_highlight = "IndentBlanklineSpaceCharBlankline"
 local context_highlight = "IndentBlanklineContextChar"
 
 M.init = function()
-    vim.g.indent_blankline_namespace = vim.api.nvim_create_namespace "indent_blankline"
+    if not vim.g.indent_blankline_namespace then
+        vim.g.indent_blankline_namespace = vim.api.nvim_create_namespace "indent_blankline"
+    end
 
     utils.reset_highlights()
 

--- a/plugin/indent_blankline.vim
+++ b/plugin/indent_blankline.vim
@@ -34,5 +34,6 @@ augroup IndentBlanklineAutogroup
     autocmd OptionSet list,shiftwidth,tabstop,expandtab IndentBlanklineRefresh
     autocmd FileChangedShellPost,TextChanged,TextChangedI,CompleteChanged,WinScrolled,BufWinEnter,Filetype * IndentBlanklineRefresh
     autocmd ColorScheme * lua require("indent_blankline.utils").reset_highlights()
+    autocmd VimEnter * lua require("indent_blankline").init()
 augroup END
 


### PR DESCRIPTION
* Memoize the find indent function
* Run init on VimEnter to initialize indents in all open windows
* Run init on plugin load to work with lazy loading