### PR TITLE
 feature: allow empty string for indent char

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ vim.cmd [[highlight IndentBlanklineIndent1 guibg=#1f1f1f gui=nocombine]]
 vim.cmd [[highlight IndentBlanklineIndent2 guibg=#1a1a1a gui=nocombine]]
 
 require("indent_blankline").setup {
-    char = " ",
+    char = "",
     char_highlight_list = {
         "IndentBlanklineIndent1",
         "IndentBlanklineIndent2",

--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -117,6 +117,13 @@ g:indent_blankline_char                              *g:indent_blankline_char*
     Specifies the character to be used as indent line.
     Not used if |g:indent_blankline_char_list| is not empty.
 
+    When set explicitly to empty string (""), no indentation character is
+    displayed at all, even when |g:indent_blankline_char_list| is not empty.
+    This can be useful in combination with
+    |g:indent_blankline_space_char_highlight_list| to only rely on different
+    highlighting of different indentation levels without needing to show a
+    special character.
+
     Also set by |g:indentLine_char|
 
     Default: '│'                                                             ~

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -250,14 +250,16 @@ local refresh = function()
             for i = 1, math.min(math.max(indent, 0), local_max_indent_level) do
                 local space_count = shiftwidth
                 local context = context_active and context_indent == i
-                if i ~= 1 or first_indent then
+                local show_end_of_line_char = i == 1 and blankline and end_of_line and list_chars["eol_char"]
+                local show_indent_or_eol_char = ((i ~= 1 or first_indent) and char ~= "") or show_end_of_line_char
+                if show_indent_or_eol_char then
                     space_count = space_count - 1
                     if current_left_offset > 0 then
                         current_left_offset = current_left_offset - 1
                     else
                         table.insert(virtual_text, {
                             utils._if(
-                                i == 1 and blankline and end_of_line and list_chars["eol_char"],
+                                show_end_of_line_char,
                                 list_chars["eol_char"],
                                 utils._if(
                                     #char_list > 0,
@@ -294,7 +296,7 @@ local refresh = function()
                     -- ternary operator below in table.insert() doesn't work because it would evaluate each option regardless
                     local tmp_string
                     local index = 1 + (i - 1) * shiftwidth
-                    if i ~= 1 or first_indent then
+                    if show_indent_or_eol_char then
                         if table.maxn(virtual_string) >= index + space_count then
                             -- first char was already set above
                             tmp_string = table.concat(virtual_string, "", index + 1, index + space_count)
@@ -328,7 +330,8 @@ local refresh = function()
             end
 
             if
-                ((blankline or extra) and trail_indent)
+                char ~= ""
+                and ((blankline or extra) and trail_indent)
                 and (first_indent or #virtual_text > 0)
                 and current_left_offset < 1
                 and indent < local_max_indent_level


### PR DESCRIPTION
Addresses #254 

1. Check if `char` variable is set and only insert indent character when
   not empty. Insert additional character from real underlying
   whitespace instead.

When setting the `char = ""` before, the resulting virtual text would
have been too short since it won't insert any character as a
replacement.  This also affected the highlighting of the virtual text.
Additionally when no indent char was desired, the only way to "ignore"
it was to set `char` to a space. This, however, doesn't look good when
also displaying `listchars` because it will insert an empty space even
when the user has set a different character to be displayed in place of
a space.

<s>2. Use `options.space_char_highlight_list` before sourcing
   `vim.g.indent_blankline_space_char_blankline_highlight_list`.

For some reason `utils.first_not_nil()` won't get past the global vim
variable even if it isn't set and therefore never gets to the option
that was passed to the setup function for fallback. If the user passed
in a list for one of the settings it is save to assume they would have
also passed a list for the other one if they wanted them to be unique
instead of setting a mish-mash of function arguments and global vim
variables.</s>

3. Change README.md to reflect new option when sensible.

