### PR TITLE
fix(refresh): fix range updates when scrolling

### DIFF
--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -184,6 +184,8 @@ local refresh = function(scroll)
     end
 
     if scroll then
+        local updated_range
+
         if vim.b.__indent_blankline_ranges[left_offset_s] then
             local blankline_ranges = vim.b.__indent_blankline_ranges[left_offset_s]
             local need_to_update = true
@@ -208,10 +210,15 @@ local refresh = function(scroll)
             end
 
             -- merge ranges and update the variable, strategies are: contains or extends
-            vim.b.__indent_blankline_ranges[left_offset_s] = utils.merge_ranges(blankline_ranges)
+            updated_range = utils.merge_ranges(blankline_ranges)
         else
-            vim.b.__indent_blankline_ranges[left_offset_s] = { { offset, range } }
+            updated_range = { { offset, range } }
         end
+
+        -- we can't assign directly to a table key, so we update the reference to the variable
+        local new_ranges = vim.b.__indent_blankline_ranges
+        new_ranges[left_offset_s] = updated_range
+        vim.b.__indent_blankline_ranges = new_ranges
     else
         vim.b.__indent_blankline_ranges = { [left_offset_s] = { { offset, range } } }
     end


### PR DESCRIPTION
Fixes bug introduced by 1b554c6183e54b3f1d7266ecc9d3be1aa1a58349, where the ranges table wasn't getting updated at all, effectively nullifying the scrolling optimization.

For some reason when you directly assign a value to a key in `vim.b.my_table`, the table doesn't actually update, so a solution is to assign the table to a local variable, change the key in that local variable, then assign the variable to `vim.b.my_table`. I don't know if it's related to the way neovim accesses values from lua or why this happens, but if you have a better solution let me know.