### PR TITLE
feat: support dotted filetypes for exclusions

### DIFF
--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -70,9 +70,14 @@ M.is_indent_blankline_enabled = M.memo(
             return false
         end
 
+        local undotted_filetypes = vim.split(filetype, ".", { plain = true })
+        table.insert(undotted_filetypes, filetype)
+
         for _, ft in ipairs(filetype_exclude) do
-            if ft == filetype then
-                return false
+            for _, undotted_filetype in ipairs(undotted_filetypes) do
+                if undotted_filetype == ft then
+                    return false
+                end
             end
         end
 


### PR DESCRIPTION
As described in `:h 'filetype'`, Vim supports compound filetypes, where a dot is used to glue together multiple filetypes. For example, a filetype of "javascript.jest" would indicate that the file contains both "javascript" and "jest" syntax.

Just say the user wants to turn off indent-blankline.nvim in all "javascript" files. The previous implementation meant that they would have to add not only "javascript", but "javascript.jest" and any other dotted filetypes that they might see, because the code was looking for an exact match.

This PR explodes filetypes such as "javascript.jest" into a list-like table of "javascript" and "jest", and it checks each one against the exclusion list individually, as well as jointly.

This means the user can add "javascript" to their `vim.g.indent_blankline_filetype_exclude` list, and it will turn off indent-blankline for any "javascript" file, dotted or not. (If the user wants to turn it off for just "javascript.jest" files, they would add "javascript.jest" to `vim.g.indent_blankline_filetype_exclude` instead.)

We might consider making a similar change to the handling of the include list (ie. `vim.g.indent_blankline_filetype`), but as I don't use that setting, I don't have a pre-formed opinion about whether it is better for it to be restrictive (favoring an exact match) or loose (favoring a flexible match).