### PR TITLE
Version 2.13.0

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,22 +1,43 @@
 name: Pull request check
 
 on:
-    pull_request:
+  pull_request:
 
 jobs:
-    format:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: JohnnyMorganz/stylua-action@1.0.0
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  args: --check .
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JohnnyMorganz/stylua-action@1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --check .
 
-    block-fixup:
-        runs-on: ubuntu-latest
+  block-fixup:
+    runs-on: ubuntu-latest
 
-        steps:
-            - uses: actions/checkout@v2
-            - name: Block Fixup Commit Merge
-              uses: 13rac1/block-fixup-merge-action@v2.0.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Block Fixup Commit Merge
+        uses: 13rac1/block-fixup-merge-action@v2.0.0
+
+  luacheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - uses: leafo/gh-actions-lua@v8.0.0
+        with:
+          luaVersion: 'luajit-2.1.0-beta3'
+
+      - uses: leafo/gh-actions-luarocks@v4.0.0
+
+      - name: build
+        run: |
+          luarocks install luacheck
+
+      - name: test
+        run: |
+          luacheck lua
+

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,2 @@
+globals = { "vim", "_" }
+max_line_length = false

--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -2,7 +2,7 @@
 
 
 Author: Lukas Reineke <lukas.reineke@protonmail.com>
-Version: 2.12.1
+Version: 2.13.0
 
 ==============================================================================
 CONTENTS                                                    *indent-blankline*
@@ -659,6 +659,10 @@ g:indent_blankline_debug                            *g:indent_blankline_debug*
 
 ==============================================================================
  6. CHANGELOG                                     *indent-blankline-changelog*
+
+2.13.0
+ * Support both the concatenated string, as well as the individual |filetypes|
+   in |g:indent_blankline_filetype_exclude| when a buffer has multiple filetypes
 
 2.12.1
  * Add ext mark priority

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -259,7 +259,7 @@ local refresh = function(scroll)
     local space_char_blankline_highlight_list = v "indent_blankline_space_char_blankline_highlight_list" or {}
     local space_char_blankline = v "indent_blankline_space_char_blankline"
 
-    local list_chars = {}
+    local list_chars
     local no_tab_character = false
     -- No need to check for disable_with_nolist as this part would never be executed if "true" && nolist
     if vim.opt.list:get() then

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -188,7 +188,6 @@ M.get_current_context = function(type_patterns)
                 if node_start ~= node_end then
                     return true, node_start + 1, node_end + 1, rgx
                 end
-                node_start, node_end = nil, nil
             end
         end
         cursor_node = cursor_node:parent()
@@ -210,13 +209,15 @@ M.reset_highlights = function()
         vim.fn.synIDattr(label_highlight, "fg", "cterm"),
     }
 
-    for highlight_name, highlight in pairs {
-        IndentBlanklineChar = whitespace_fg,
-        IndentBlanklineSpaceChar = whitespace_fg,
-        IndentBlanklineSpaceCharBlankline = whitespace_fg,
-        IndentBlanklineContextChar = label_fg,
-        IndentBlanklineContextStart = label_fg,
-    } do
+    for highlight_name, highlight in
+        pairs {
+            IndentBlanklineChar = whitespace_fg,
+            IndentBlanklineSpaceChar = whitespace_fg,
+            IndentBlanklineSpaceCharBlankline = whitespace_fg,
+            IndentBlanklineContextChar = label_fg,
+            IndentBlanklineContextStart = label_fg,
+        }
+    do
         local current_highlight = vim.fn.synIDtrans(vim.fn.hlID(highlight_name))
         if
             vim.fn.synIDattr(current_highlight, "fg") == ""
@@ -246,7 +247,7 @@ M.reset_highlights = function()
 end
 
 M.first_not_nil = function(...)
-    for _, value in pairs { ... } do
+    for _, value in pairs { ... } do -- luacheck: ignore
         return value
     end
 end

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -70,9 +70,14 @@ M.is_indent_blankline_enabled = M.memo(
             return false
         end
 
+        local undotted_filetypes = vim.split(filetype, ".", { plain = true })
+        table.insert(undotted_filetypes, filetype)
+
         for _, ft in ipairs(filetype_exclude) do
-            if ft == filetype then
-                return false
+            for _, undotted_filetype in ipairs(undotted_filetypes) do
+                if undotted_filetype == ft then
+                    return false
+                end
             end
         end
 


### PR DESCRIPTION
* Support both the concatenated string, as well as the individual `filetypes` in `g:indent_blankline_filetype_exclude` when a buffer has multiple `filetypes`