### PR TITLE
Added filetype "man" to exclude list

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -389,6 +389,7 @@ g:indent_blankline_filetype_exclude      *g:indent_blankline_filetype_exclude*
         "packer",                                                            ~
         "checkhealth",                                                       ~
         "help",                                                              ~
+        "man",                                                               ~
         "",                                                                  ~
     ]                                                                        ~
 

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -80,7 +80,7 @@ M.setup = function(options)
         options.filetype_exclude,
         vim.g.indent_blankline_filetype_exclude,
         vim.g.indentLine_fileTypeExclude,
-        { "lspinfo", "packer", "checkhealth", "help", "" }
+        { "lspinfo", "packer", "checkhealth", "help", "man", "" }
     )
     vim.g.indent_blankline_bufname_exclude = o(
         options.bufname_exclude,


### PR DESCRIPTION
Hello!

I've added filetype "man" to the list of excluded filetypes. Not as commonly encountered as filetype "help" perhaps but since the Man plugin is builtin and executed through the "K" key sometimes I felt that it was appropriate to add this to the default settings upstream instead of just disabling it on my end.

/ Göran Gustafsson
