### PR TITLE
Version 2.18.1

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -2,7 +2,7 @@
 
 
 Author: Lukas Reineke <lukas.reineke@protonmail.com>
-Version: 2.18.0
+Version: 2.18.1
 
 ==============================================================================
 CONTENTS                                                    *indent-blankline*
@@ -726,6 +726,9 @@ g:indent_blankline_debug                            *g:indent_blankline_debug*
 
 ==============================================================================
  6. CHANGELOG                                     *indent-blankline-changelog*
+
+2.18.1
+  Ignore treesitter scope context if it is only one line
 
 2.18.0
   Add |g:indent_blankline_use_treesitter_scope|

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -193,6 +193,9 @@ M.get_current_context = function(type_patterns, use_treesitter_scope)
             return false
         end
         local node_start, _, node_end, _ = current_scope:range()
+        if node_start ~= node_end then
+            return false
+        end
         return true, node_start + 1, node_end + 1, current_scope:type()
     end
 


### PR DESCRIPTION
Ignore treesitter scope context if it is only one line