### PR TITLE
Avoid errors on cmdline window

### DIFF
--- a/lua/indent_blankline/commands.lua
+++ b/lua/indent_blankline/commands.lua
@@ -4,8 +4,8 @@ M.refresh = function(bang, scroll)
     scroll = scroll or false
     if bang then
         local win = vim.api.nvim_get_current_win()
-        vim.cmd(string.format([[noautocmd windo lua require("indent_blankline").refresh(%s)]], tostring(scroll)))
-        if vim.api.nvim_win_is_valid(win) then
+        vim.cmd(string.format([[silent! noautocmd windo lua require("indent_blankline").refresh(%s)]], tostring(scroll)))
+        if vim.api.nvim_win_is_valid(win) and vim.fn.getcmdwintype == "" then
             vim.api.nvim_set_current_win(win)
         end
     else


### PR DESCRIPTION
With this plugin, Neovim reports errors when the cursor goes into the cmdline window.

You can see errors below with `q:` in the normal mode.

```
Vim(lua):E5108: Error executing lua .../indent-blankline.nvim/lua/indent_blankline/commands.lua:7: Vim(windo):E11: Invalid in command-line
 window; <CR> executes, CTRL-C quits: noautocmd windo lua require(\"indent_blankline\").refresh(false)
```