### PR TITLE
Add `CursorMovedI` event to `IndentBlanklineRefresh` autocmd

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -467,7 +467,8 @@ g:indent_blankline_show_current_context *g:indent_blankline_show_current_context
     Note: Requires https://github.com/nvim-treesitter/nvim-treesitter to be
           installed
 
-    Note: With this option enabled, the plugin refreshes on |CursorMoved|,
+    Note: With this option enabled, the plugin refreshes on |CursorMoved| and
+    |CursorMovedI|,
           which might be slower
 
     Default: v:false                                                         ~

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -183,7 +183,7 @@ M.setup = function(options)
         vim.cmd [[
             augroup IndentBlanklineContextAutogroup
                 autocmd!
-                autocmd CursorMoved * IndentBlanklineRefresh
+                autocmd CursorMoved,CursorMovedI * IndentBlanklineRefresh
             augroup END
         ]]
     end


### PR DESCRIPTION
It is obvious that users shouldn't move around in insert mode, however
in some scenarios the cursor moves out of the current context in insert
mode.

For example let's say we are editing something like this

```c
if (myBool) {

} // <-- cursor is on this line
```

if the user presses `o` the cursor moves out of the if statement context
with the `CursorMovedI` event being called instead of `CursorMoved`.

Or if the user has an autopair plugin by pressing `{<cr>` that plugin
*potentially* creates a new context and moves the cursor inside that
context in insert mode.
