### PR TITLE
Add `refresh_events` option

### DIFF
--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -183,7 +183,7 @@ M.setup = function(options)
         vim.cmd [[
             augroup IndentBlanklineContextAutogroup
                 autocmd!
-                autocmd CursorMoved * IndentBlanklineRefresh
+                autocmd CursorMoved,CursorMovedI * IndentBlanklineRefresh
             augroup END
         ]]
     end


### PR DESCRIPTION
This is a better approach of the previous pr I made (#453). This time instead of hard coding the events I decided to let *the end user* choose what events should run the `IndentBlanklineRefresh` command.

Option name: `refresh_events`
Default value: `{ "CursorMoved" }`

As I mentioned in the commit message please add this to the help tag since I don't know much about that. Thanks!