### PR TITLE
Added buftype "prompt" to exclude list

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -421,6 +421,7 @@ g:indent_blankline_buftype_exclude        *g:indent_blankline_buftype_exclude*
         "terminal",                                                          ~
         "nofile",                                                            ~
         "quickfix",                                                          ~
+        "prompt",                                                            ~
     ]                                                                        ~
 
     Example: >

--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -69,7 +69,7 @@ M.setup = function(options)
         options.buftype_exclude,
         vim.g.indent_blankline_buftype_exclude,
         vim.g.indentLine_bufTypeExclude,
-        { "terminal", "nofile", "quickfix" }
+        { "terminal", "nofile", "quickfix", "prompt" }
     )
     vim.g.indent_blankline_viewport_buffer = o(options.viewport_buffer, vim.g.indent_blankline_viewport_buffer, 10)
     vim.g.indent_blankline_use_treesitter = o(options.use_treesitter, vim.g.indent_blankline_use_treesitter, false)


### PR DESCRIPTION
I've added filetype "TelescopePrompt" to the list of excluded filetypes.
Like packer, it's a de facto standard plugin, so I thought it would be nice to have it in the default settings.