### PR TITLE
Remove if helptags

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -110,7 +110,7 @@ When defining the highlight group, it is important to set |nocombine| as a
 gui option. This is to make sure the character does not inherit gui options
 from the underlying text, like italic or bold.
 
-Highlight groups get reset on |ColorScheme| autocommand, *if* both fg and bg
+Highlight groups get reset on |ColorScheme| autocommand, if both fg and bg
 are empty.
 
 The set more than one highlight group that changes based on indentation level,


### PR DESCRIPTION
Because the doc contains an if tag, it conflicts with the if in the vim doc and causes an error.
The error in dein is as follows.
```
[dein] Error generating helptags:
[dein] Vim(helptags):E154: Duplicate tag "if" in file /Users/yuki-yano/.vim/bundle/.cache/init.vim/.dein/doc/indent_blankline.txt
[dein] function dein#recache_runtimepath[1]..dein#install#_recache_runtimepath[31]..<SNR>175_helptags, line 10
```