### PR TITLE
Left aligned vertical bar character

### DIFF
--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -24,7 +24,7 @@ M.setup = function(options)
 
     local o = utils.first_not_nil
 
-    vim.g.indent_blankline_char = o(options.char, vim.g.indent_blankline_char, vim.g.indentLine_char, "│")
+    vim.g.indent_blankline_char = o(options.char, vim.g.indent_blankline_char, vim.g.indentLine_char, "▏")
     vim.g.indent_blankline_char_blankline = o(options.char_blankline, vim.g.indent_blankline_char_blankline)
     vim.g.indent_blankline_char_list =
         o(options.char_list, vim.g.indent_blankline_char_list, vim.g.indentLine_char_list)


### PR DESCRIPTION
With this vertical line character we probably won't need `modify_font` as it is already on the left edge of the character box.

Example usage in iTerm2:

<img width="698" alt="image" src="https://user-images.githubusercontent.com/1270688/193277326-04c3726b-4903-4422-9557-c183ab72cbe2.png">
