### PR TITLE
doc: add note for custom `indent_blankline_char_highlight_list`

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -105,6 +105,8 @@ IndentBlanklineContextStart                     *hl-IndentBlanklineContextStart*
 
 ------------------------------------------------------------------------------
 
+Note: Define your highlight group after setting colorscheme or your colorscheme will clear your highlight group
+
 When defining the highlight group, it is important to set |nocombine| as a
 gui option. This is to make sure the character does not inherit gui options
 from the underlying text, like italic or bold.


### PR DESCRIPTION
## Description
i tried this [this example](https://github.com/lukas-reineke/indent-blankline.nvim/blob/master/README.md#with-custom-gindent_blankline_char_highlight_list) in `README.md`

it did not work and indent lines color was white 
so the reason for this was because i was setting my colorscheme(in after/plugin/color.lua) after my `indent-blankline.nvim` config
and colorschemes will clear all highlights with `highlight clear` before setting their own colors

So why not add a note for anyone using `char_highlight_list` :)

### Example of a colorscheme clearing highlights
https://github.com/joshdick/onedark.vim/blob/b6b5ffe31a195a3077338d7a506b905e4a51590f/colors/onedark.vim#L49


### Also read
https://vi.stackexchange.com/questions/3355/why-do-custom-highlights-in-my-vimrc-get-cleared-or-reset-to-default