### PR TITLE
doc: in README.md examples use `vim.api.nvim_set_hl` instead of `vim.cmd([[highlight ...]])`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ require("indent_blankline").setup {
 
 ```lua
 vim.opt.termguicolors = true
-vim.cmd [[highlight IndentBlanklineIndent1 guifg=#E06C75 gui=nocombine]]
-vim.cmd [[highlight IndentBlanklineIndent2 guifg=#E5C07B gui=nocombine]]
-vim.cmd [[highlight IndentBlanklineIndent3 guifg=#98C379 gui=nocombine]]
-vim.cmd [[highlight IndentBlanklineIndent4 guifg=#56B6C2 gui=nocombine]]
-vim.cmd [[highlight IndentBlanklineIndent5 guifg=#61AFEF gui=nocombine]]
-vim.cmd [[highlight IndentBlanklineIndent6 guifg=#C678DD gui=nocombine]]
+vim.api.nvim_set_hl(0, "IndentBlanklineIndent1", { fg = "#E06C75", nocombine = true })
+vim.api.nvim_set_hl(0, "IndentBlanklineIndent2", { fg = "#E5C07B", nocombine = true })
+vim.api.nvim_set_hl(0, "IndentBlanklineIndent3", { fg = "#98C379", nocombine = true })
+vim.api.nvim_set_hl(0, "IndentBlanklineIndent4", { fg = "#56B6C2", nocombine = true })
+vim.api.nvim_set_hl(0, "IndentBlanklineIndent5", { fg = "#61AFEF", nocombine = true })
+vim.api.nvim_set_hl(0, "IndentBlanklineIndent6", { fg = "#C678DD", nocombine = true })
 
 vim.opt.list = true
 vim.opt.listchars:append "space:⋅"
@@ -118,8 +118,8 @@ require("indent_blankline").setup {
 
 ```lua
 vim.opt.termguicolors = true
-vim.cmd [[highlight IndentBlanklineIndent1 guibg=#1f1f1f gui=nocombine]]
-vim.cmd [[highlight IndentBlanklineIndent2 guibg=#1a1a1a gui=nocombine]]
+vim.api.nvim_set_hl(0, "IndentBlanklineIndent1", { fg = "#1f1f1f", nocombine = true })
+vim.api.nvim_set_hl(0, "IndentBlanklineIndent2", { fg = "#1a1a1a", nocombine = true })
 
 require("indent_blankline").setup {
     char = "",


### PR DESCRIPTION
no need to use vimscript for this :)