### PR TITLE
Improved detection for present highlight groups

### DIFF
--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -245,7 +245,6 @@ M.reset_highlights = function()
         IndentBlanklineContextChar = label_fg,
         IndentBlanklineContextStart = label_fg,
     } do
-        local current_highlight = vim.fn.synIDtrans(vim.fn.hlID(highlight_name))
         if not M.check_hightligt_exists(highlight_name) then
             if highlight_name == "IndentBlanklineContextStart" then
                 vim.cmd(

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -246,11 +246,7 @@ M.reset_highlights = function()
         IndentBlanklineContextStart = label_fg,
     } do
         local current_highlight = vim.fn.synIDtrans(vim.fn.hlID(highlight_name))
-        if
-            vim.fn.synIDattr(current_highlight, "fg") == ""
-            and vim.fn.synIDattr(current_highlight, "bg") == ""
-            and vim.fn.synIDattr(current_highlight, "sp") == ""
-        then
+        if not M.check_hightligt_exists(highlight_name) then
             if highlight_name == "IndentBlanklineContextStart" then
                 vim.cmd(
                     string.format(
@@ -271,6 +267,11 @@ M.reset_highlights = function()
             end
         end
     end
+end
+
+M.check_hightligt_exists = function(highlight_name)
+    local highlight_status, _ = pcall(vim.cmd, 'silent highlight ' .. highlight_name)
+    return highlight_status
 end
 
 M.first_not_nil = function(...)


### PR DESCRIPTION
Before, it used to check if `fg`, `bg`, or `sp` are present, and if no created a highlight group. It would make impossible for a cterm only color scheme to redefine these highlight groups.

Now, it simply checks if the highlight group was already created before.