### PR TITLE
add `match`  to context patterns

### DIFF
--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -109,6 +109,7 @@ M.setup = function(options)
         "with",
         "try",
         "except",
+        "match",
         "arguments",
         "argument_list",
         "object",


### PR DESCRIPTION
Currently the context is shown like this. The `match` block is not highlighted.

![without](https://user-images.githubusercontent.com/35634100/219770166-4c4d2201-9b97-4f32-b476-1c7792c0cd2d.png)

With the patch, the `match` block is shown as context.

![with](https://user-images.githubusercontent.com/35634100/219770387-0dca4a69-641b-4655-af1d-9fc8b30b6992.png)
