### PR TITLE
added treesitter support for zig

### DIFF
--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -118,6 +118,14 @@ M.setup = function(options)
         "table",
         "tuple",
         "do_block",
+		"Block",
+		"InitList",
+		"FnCallArguments",
+		"IfStatement",
+		"ContainerDecl",
+		"SwitchExpr",
+		"IfExpr",
+		"ParamDeclList",
     })
     vim.g.indent_blankline_context_pattern_highlight =
         o(options.context_pattern_highlight, vim.g.indent_blankline_context_pattern_highlight)


### PR DESCRIPTION
The treesitter commands for Zig differ, which is why context highlighting did not work. I have added the necessary commands in this PR.