### PR TITLE
fix problem where context is incorrectly parsed when hovering comments

### DIFF
--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -187,17 +187,17 @@ M.find_indent = function(whitespace, only_whitespace, shiftwidth, strict_tabs, l
 end
 
 M.get_current_context = function(type_patterns, use_treesitter_scope)
-    local ts_locals_status, locals = pcall(require, "nvim-treesitter.locals")
-    if not ts_locals_status then
-        vim.schedule_wrap(function()
-            M.error_handler("nvim-treesitter not found. Context will not work", vim.log.levels.WARN)
-        end)()
-        return false
-    end
 
     local cursor_node = vim.treesitter.get_node()
 
     if use_treesitter_scope then
+        local ts_locals_status, locals = pcall(require, "nvim-treesitter.locals")
+        if not ts_locals_status then
+            vim.schedule_wrap(function()
+                M.error_handler("nvim-treesitter not found. Context will not work", vim.log.levels.WARN)
+            end)()
+            return false
+        end
         local current_scope = locals.containing_scope(cursor_node, 0)
         if not current_scope then
             return false

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -187,8 +187,8 @@ M.find_indent = function(whitespace, only_whitespace, shiftwidth, strict_tabs, l
 end
 
 M.get_current_context = function(type_patterns, use_treesitter_scope)
-    local ts_utils_status, locals = pcall(require, "nvim-treesitter.locals")
-    if not ts_utils_status then
+    local ts_locals_status, locals = pcall(require, "nvim-treesitter.locals")
+    if not ts_locals_status then
         vim.schedule_wrap(function()
             M.error_handler("nvim-treesitter not found. Context will not work", vim.log.levels.WARN)
         end)()

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -187,14 +187,14 @@ M.find_indent = function(whitespace, only_whitespace, shiftwidth, strict_tabs, l
 end
 
 M.get_current_context = function(type_patterns, use_treesitter_scope)
-    local ts_utils_status, ts_utils = pcall(require, "nvim-treesitter.ts_utils")
+    local ts_utils_status, locals = pcall(require, "nvim-treesitter.locals")
     if not ts_utils_status then
         vim.schedule_wrap(function()
             M.error_handler("nvim-treesitter not found. Context will not work", vim.log.levels.WARN)
         end)()
         return false
     end
-    local locals = require "nvim-treesitter.locals"
+
     local cursor_node = vim.treesitter.get_node()
 
     if use_treesitter_scope then

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -187,26 +187,25 @@ M.find_indent = function(whitespace, only_whitespace, shiftwidth, strict_tabs, l
 end
 
 M.get_current_context = function(type_patterns, use_treesitter_scope)
-    local ts_utils_status, ts_utils = pcall(require, "nvim-treesitter.ts_utils")
-    if not ts_utils_status then
-        vim.schedule_wrap(function()
-            M.error_handler("nvim-treesitter not found. Context will not work", vim.log.levels.WARN)
-        end)()
-        return false
-    end
-    local locals = require "nvim-treesitter.locals"
     local cursor_node = vim.treesitter.get_node()
 
     if use_treesitter_scope then
-        local current_scope = locals.containing_scope(cursor_node, 0)
-        if not current_scope then
-            return false
+        local success, locals = pcall(require, "nvim-treesitter.locals")
+        if not success then
+            vim.schedule_wrap(function()
+                M.error_handler("nvim-treesitter not found. Defaulting to patterns.", vim.log.levels.WARN)
+            end)()
+        else
+            local current_scope = locals.containing_scope(cursor_node, 0)
+            if not current_scope then
+                return false
+            end
+            local node_start, _, node_end, _ = current_scope:range()
+            if node_start == node_end then
+                return false
+            end
+            return true, node_start + 1, node_end + 1, current_scope:type()
         end
-        local node_start, _, node_end, _ = current_scope:range()
-        if node_start == node_end then
-            return false
-        end
-        return true, node_start + 1, node_end + 1, current_scope:type()
     end
 
     while cursor_node do
@@ -247,9 +246,9 @@ M.reset_highlights = function()
     } do
         local current_highlight = vim.fn.synIDtrans(vim.fn.hlID(highlight_name))
         if
-            vim.fn.synIDattr(current_highlight, "fg") == ""
-            and vim.fn.synIDattr(current_highlight, "bg") == ""
-            and vim.fn.synIDattr(current_highlight, "sp") == ""
+                vim.fn.synIDattr(current_highlight, "fg") == ""
+                and vim.fn.synIDattr(current_highlight, "bg") == ""
+                and vim.fn.synIDattr(current_highlight, "sp") == ""
         then
             if highlight_name == "IndentBlanklineContextStart" then
                 vim.cmd(

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -187,25 +187,26 @@ M.find_indent = function(whitespace, only_whitespace, shiftwidth, strict_tabs, l
 end
 
 M.get_current_context = function(type_patterns, use_treesitter_scope)
+    local ts_utils_status, ts_utils = pcall(require, "nvim-treesitter.ts_utils")
+    if not ts_utils_status then
+        vim.schedule_wrap(function()
+            M.error_handler("nvim-treesitter not found. Context will not work", vim.log.levels.WARN)
+        end)()
+        return false
+    end
+    local locals = require "nvim-treesitter.locals"
     local cursor_node = vim.treesitter.get_node()
 
     if use_treesitter_scope then
-        local success, locals = pcall(require, "nvim-treesitter.locals")
-        if not success then
-            vim.schedule_wrap(function()
-                M.error_handler("nvim-treesitter not found. Defaulting to patterns.", vim.log.levels.WARN)
-            end)()
-        else
-            local current_scope = locals.containing_scope(cursor_node, 0)
-            if not current_scope then
-                return false
-            end
-            local node_start, _, node_end, _ = current_scope:range()
-            if node_start == node_end then
-                return false
-            end
-            return true, node_start + 1, node_end + 1, current_scope:type()
+        local current_scope = locals.containing_scope(cursor_node, 0)
+        if not current_scope then
+            return false
         end
+        local node_start, _, node_end, _ = current_scope:range()
+        if node_start == node_end then
+            return false
+        end
+        return true, node_start + 1, node_end + 1, current_scope:type()
     end
 
     while cursor_node do

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -195,7 +195,7 @@ M.get_current_context = function(type_patterns, use_treesitter_scope)
         return false
     end
     local locals = require "nvim-treesitter.locals"
-    local cursor_node = ts_utils.get_node_at_cursor()
+    local cursor_node = vim.treesitter.get_node()
 
     if use_treesitter_scope then
         local current_scope = locals.containing_scope(cursor_node, 0)

--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -246,9 +246,9 @@ M.reset_highlights = function()
     } do
         local current_highlight = vim.fn.synIDtrans(vim.fn.hlID(highlight_name))
         if
-                vim.fn.synIDattr(current_highlight, "fg") == ""
-                and vim.fn.synIDattr(current_highlight, "bg") == ""
-                and vim.fn.synIDattr(current_highlight, "sp") == ""
+            vim.fn.synIDattr(current_highlight, "fg") == ""
+            and vim.fn.synIDattr(current_highlight, "bg") == ""
+            and vim.fn.synIDattr(current_highlight, "sp") == ""
         then
             if highlight_name == "IndentBlanklineContextStart" then
                 vim.cmd(


### PR DESCRIPTION
For some reason `ts_utils` parses comments as `source` causing context parsing to result in an error. This fixes the issue by using `vim.treesitter` instead.