### PR TITLE
Fix for Ruby 'unless' blocks

### DIFF
--- a/lua/indent_blankline/init.lua
+++ b/lua/indent_blankline/init.lua
@@ -118,14 +118,15 @@ M.setup = function(options)
         "table",
         "tuple",
         "do_block",
-		"Block",
-		"InitList",
-		"FnCallArguments",
-		"IfStatement",
-		"ContainerDecl",
-		"SwitchExpr",
-		"IfExpr",
-		"ParamDeclList",
+        "Block",
+        "InitList",
+        "FnCallArguments",
+        "IfStatement",
+        "ContainerDecl",
+        "SwitchExpr",
+        "IfExpr",
+        "ParamDeclList",
+        "unless",
     })
     vim.g.indent_blankline_context_pattern_highlight =
         o(options.context_pattern_highlight, vim.g.indent_blankline_context_pattern_highlight)


### PR DESCRIPTION
Although its usefulness may be subject to debate, Ruby includes an `unless` block. This block isn't currently recognized by indent-blankline's `show_current_context` feature.

- Add support for ruby's `unless` blocks
- Fix some inconsistent whitespace

Here is a before and after screenshot.

## Before:
The cursor is on line 8.
The context line is on lines 4-11 instead of the expected 5-8.
<img width="567" alt="image" src="https://github.com/lukas-reineke/indent-blankline.nvim/assets/934490/619fc95c-e896-4068-8ab1-20cdd40bcfc7">

## After:
The cursor is on line 8.
The context line is on lines 5-8, which is what one would expect.
<img width="500" alt="image" src="https://github.com/lukas-reineke/indent-blankline.nvim/assets/934490/74b06cd3-4d4c-472a-a659-b1856138a82a">
