### PR TITLE
add checks for cterm highlights before highlights reset

### DIFF
--- a/lua/indent_blankline/utils.lua
+++ b/lua/indent_blankline/utils.lua
@@ -250,6 +250,8 @@ M.reset_highlights = function()
             vim.fn.synIDattr(current_highlight, "fg") == ""
             and vim.fn.synIDattr(current_highlight, "bg") == ""
             and vim.fn.synIDattr(current_highlight, "sp") == ""
+            and vim.fn.synIDattr(current_highlight, "fg", "cterm") == ""
+            and vim.fn.synIDattr(current_highlight, "bg", "cterm") == ""
         then
             if highlight_name == "IndentBlanklineContextStart" then
                 vim.cmd(


### PR DESCRIPTION
fixes #606

This could be a neovim issue. Quote from help (note the last sentence):
```
synIDattr({synID}, {what} [, {mode}])			*synIDattr()*
		The result is a String, which is the {what} attribute of
		syntax ID {synID}.  This can be used to obtain information
		about a syntax item.
		{mode} can be "gui" or "cterm", to get the attributes
		for that mode.  When {mode} is omitted, or an invalid value is
		used, the attributes for the currently active highlighting are
		used (GUI or cterm).
```
But it seems to only detect that I'm using cterm highlighting when I change colorscheme from within neovim, but not when I set colorscheme from my vimrc. Maybe the "currently active highlighting" is only defined after neovim launches.

Anyways, this seems like a simple fix.