### PR TITLE
feat: Add highlight groups

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -9,8 +9,9 @@ CONTENTS                                              *ibl* *indent-blankline*
   1. Introduction                          |ibl.introduction|
   2. Functions                             |ibl.functions|
   3. Types                                 |ibl.types|
-  4. Commands                              |ibl.commands|
-  5. License                               |ibl.license|
+  4. Highlights                            |ibl.highlights|
+  5. Commands                              |ibl.commands|
+  6. License                               |ibl.license|
 
 ==============================================================================
  1. INTRODUCTION                                            *ibl.introduction*
@@ -266,7 +267,7 @@ config.indent                                              *ibl.config.indent*
                          Highlight group, or list of highlight groups, that
                          get applied to the indentation guide
 
-                         Default: |hl-Whitespace| ~
+                         Default: |hl-IblIndent| ~
 
                                           *ibl.config.indent.smart_indent_cap*
    • {smart_indent_cap}  (boolean)
@@ -316,7 +317,7 @@ config.whitespace                                      *ibl.config.whitespace*
                                Highlight group, or list of highlight groups,
                                that get applied to the whitespace
 
-                               Default: |hl-Whitespace| ~
+                               Default: |hl-IblWhitespace| ~
 
                                 *ibl.config.whitespace.remove_blankline_trail*
    • {remove_blankline_trail}  (boolean)
@@ -388,7 +389,7 @@ config.scope                                                *ibl.config.scope*
                            Highlight group, or list of highlight groups,
                            that get applied to the scope
 
-                           Default: |hl-LineNr| ~
+                           Default: |hl-IblScope| ~
 
                                                    *ibl.config.scope.priority*
    • {priority}            (number)
@@ -760,7 +761,30 @@ hooks.builtin.hide_tab_space_indent_level
    )
 <
 ==============================================================================
- 4. COMMANDS                                                    *ibl.commands*
+ 4. HIGHLIGHTS                                                *ibl.highlights*
+
+IblIndent                                                       *hl-IblIndent*
+
+ The default highlight group for indentation characters.
+
+ Default: takes the values from |hl-Whitespace| when not defined ~
+
+
+IblWhitespace                                               *hl-IblWhitespace*
+
+ The default highlight group for whitespace characters.
+
+ Default: takes the values from |hl-Whitespace| when not defined ~
+
+
+IblScope                                                         *hl-IblScope*
+
+ The default highlight group for |ibl.config.scope| characters.
+
+ Default: takes the values from |hl-LineNr| when not defined ~
+
+==============================================================================
+ 5. COMMANDS                                                    *ibl.commands*
 
 :IBLEnable                                                        *:IBLEnable*
 
@@ -787,7 +811,7 @@ hooks.builtin.hide_tab_space_indent_level
  Toggles indent-blanklines scope on and off
 
 ==============================================================================
- 5. LICENSE                                                      *ibl.license*
+ 6. LICENSE                                                      *ibl.license*
 
  The MIT Licence
  http://www.opensource.org/licenses/mit-license.php

--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -26,12 +26,12 @@ M.default_config = {
     indent = {
         char = "▎",
         tab_char = nil,
-        highlight = "Whitespace",
+        highlight = "IblIndent",
         smart_indent_cap = true,
         priority = 1,
     },
     whitespace = {
-        highlight = "Whitespace",
+        highlight = "IblWhitespace",
         remove_blankline_trail = true,
     },
     scope = {
@@ -40,7 +40,7 @@ M.default_config = {
         show_start = true,
         show_end = true,
         injected_languages = true,
-        highlight = "LineNr",
+        highlight = "IblScope",
         priority = 1024,
         include = {
             node_type = {},

--- a/lua/ibl/highlights.lua
+++ b/lua/ibl/highlights.lua
@@ -14,6 +14,32 @@ local M = {
     scope = {},
 }
 
+local get = function(name)
+    return vim.api.nvim_get_hl(0, { name = name })
+end
+
+local not_set = function(hl)
+    return not hl or vim.tbl_count(hl) == 0
+end
+
+local setup_builtin_hl_groups = function()
+    local whitespace_hl = get "Whitespace"
+    local line_nr_hl = get "LineNr"
+    local ibl_indent_hl_name = "IblIndent"
+    local ibl_whitespace_hl_name = "IblWhitespace"
+    local ibl_scope_hl_name = "IblScope"
+
+    if not_set(get(ibl_indent_hl_name)) then
+        vim.api.nvim_set_hl(0, ibl_indent_hl_name, whitespace_hl)
+    end
+    if not_set(get(ibl_whitespace_hl_name)) then
+        vim.api.nvim_set_hl(0, ibl_whitespace_hl_name, whitespace_hl)
+    end
+    if not_set(get(ibl_scope_hl_name)) then
+        vim.api.nvim_set_hl(0, ibl_scope_hl_name, line_nr_hl)
+    end
+end
+
 M.setup = function()
     local config = conf.get_config(-1)
 
@@ -23,12 +49,7 @@ M.setup = function()
         fn()
     end
 
-    local get = function(name)
-        return vim.api.nvim_get_hl(0, { name = name })
-    end
-    local not_set = function(hl)
-        return not hl or vim.tbl_count(hl) == 0
-    end
+    setup_builtin_hl_groups()
 
     local indent_highlights = config.indent.highlight
     if type(indent_highlights) == "string" then


### PR DESCRIPTION
Add `IblIndent`, `IblWhitespace`, and `IblScope`, that default to `Whitespace` and `LineNr` like before. This allows color schemes to overwrite the colors.

see `:help ibl.highlights`