### PR TITLE
fix: c scope

### DIFF
--- a/lua/ibl/scope_languages.lua
+++ b/lua/ibl/scope_languages.lua
@@ -42,7 +42,6 @@ local M = {
         for_statement = true,
         if_statement = true,
         while_statement = true,
-        translation_unit = true,
         function_definition = true,
         compound_statement = true,
         struct_specifier = true,


### PR DESCRIPTION
Remove `translation_unit` from c scope because it will cause the whole file to become scope

fix #657