### PR TITLE
`current_indent` without treesitter

### DIFF
--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -62,7 +62,7 @@ M.default_config = {
         },
     },
     current_indent = {
-        enabled = false,
+        enabled = true,
         char = nil,
         priority = 2,
         highlight = "IblCurrentIndent",
@@ -121,6 +121,7 @@ local validate_config = function(config)
         indent = { config.indent, "table", true },
         whitespace = { config.whitespace, "table", true },
         scope = { config.scope, "table", true },
+        current_indent = { config.current_indent, "table", true },
         exclude = { config.exclude, "table", true },
     }, config, "ibl.config")
 
@@ -231,6 +232,15 @@ local validate_config = function(config)
                 node_type = { config.scope.include.node_type, "table", true },
             }, config.scope.include, "ibl.config.scope.include")
         end
+    end
+
+    if config.current_indent then
+        utils.validate({
+            enabled = { config.scope.enabled, "boolean", true },
+            char = { config.scope.char, "string", true },
+            highlight = { config.scope.highlight, "string", true },
+            priority = { config.scope.priority, "number", true },
+        }, config.current_indent, "ibl.config.current_indent")
     end
 
     if config.exclude then

--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -61,6 +61,12 @@ M.default_config = {
             },
         },
     },
+    current_indent = {
+        enabled = false,
+        char = nil,
+        priority = 2,
+        highlight = "IblCurrentIndent",
+    },
     exclude = {
         filetypes = {
             "lspinfo",

--- a/lua/ibl/config.types.lua
+++ b/lua/ibl/config.types.lua
@@ -15,6 +15,8 @@
 ---@field whitespace ibl.config.whitespace?
 --- Configures the scope
 ---@field scope ibl.config.scope?
+--- Configures the current_indent
+---@field current_indent ibl.config.current_indent?
 --- Configures what is excluded from indent-blankline
 ---@field exclude ibl.config.exclude?
 
@@ -75,6 +77,18 @@
 --- Configures nodes or languages to be excluded from scope
 ---@field exclude ibl.config.scope.exclude?
 
+---@class ibl.config.current_indent
+--- Enables or disables scope
+---@field enabled boolean?
+--- Character, or list of characters, that get used to display the scope indentation guide
+---
+--- Each character has to have a display width of 0 or 1
+---@field char string?
+--- Highlight group, or list of highlight groups, that get applied to the scope
+---@field highlight string?
+--- Virtual text priority for the scope
+---@field priority number?
+
 ---@class ibl.config.scope.include
 --- map of language to a list of node types which can be used as scope
 ---
@@ -126,7 +140,9 @@
 --- Configures the whitespace
 ---@field whitespace ibl.config.full.whitespace: ibl.config.whitespace
 --- Configures the scope
----@field scope ibl.config.full.scope: ig.config.scope
+---@field scope ibl.config.full.scope: ibl.config.scope
+--- Configures the scope
+---@field current_indent ibl.config.full.current_indent: ibl.config.current_indent
 --- Configures what is excluded from indent-blankline
 ---@field exclude ibl.config.full.exclude: ibl.config.exclude
 
@@ -186,6 +202,18 @@
 ---@field include ibl.config.full.scope.include
 --- Configures nodes or languages to be excluded from scope
 ---@field exclude ibl.config.full.scope.exclude: ibl.config.scope.exclude
+
+---@class ibl.config.full.current_indent: ibl.config.current_indent
+--- Enables or disables scope
+---@field enabled boolean
+--- Character, or list of characters, that get used to display the scope indentation guide
+---
+--- Each character has to have a display width of 0 or 1
+---@field char string?
+--- Highlight group, or list of highlight groups, that get applied to the scope
+---@field highlight string
+--- Virtual text priority for the scope
+---@field priority number
 
 ---@class ibl.config.full.scope.include: ibl.config.scope.include
 --- map of language to a list of node types which can be used as scope

--- a/lua/ibl/highlights.lua
+++ b/lua/ibl/highlights.lua
@@ -32,9 +32,11 @@ end
 local setup_builtin_hl_groups = function()
     local whitespace_hl = get "Whitespace"
     local line_nr_hl = get "LineNr"
+    local cursor_line_nr_hl = get "CursorLineNr"
     local ibl_indent_hl_name = "IblIndent"
     local ibl_whitespace_hl_name = "IblWhitespace"
     local ibl_scope_hl_name = "IblScope"
+    local ibl_current_indent_hl_name = "IblCurrentIndent"
 
     if not_set(get(ibl_indent_hl_name)) then
         vim.api.nvim_set_hl(0, ibl_indent_hl_name, whitespace_hl)
@@ -45,13 +47,16 @@ local setup_builtin_hl_groups = function()
     if not_set(get(ibl_scope_hl_name)) then
         vim.api.nvim_set_hl(0, ibl_scope_hl_name, line_nr_hl)
     end
+    if not_set(get(ibl_current_indent_hl_name)) then
+        vim.api.nvim_set_hl(0, ibl_current_indent_hl_name, cursor_line_nr_hl)
+    end
 end
 
 M.setup = function()
     local config = conf.get_config(-1)
 
     for _, fn in
-        pairs(hooks.get(-1, hooks.type.HIGHLIGHT_SETUP) --[[ @as ibl.hooks.cb.highlight_setup[] ]])
+    pairs(hooks.get(-1, hooks.type.HIGHLIGHT_SETUP) --[[ @as ibl.hooks.cb.highlight_setup[] ]])
     do
         fn()
     end
@@ -106,6 +111,17 @@ M.setup = function()
         vim.api.nvim_set_hl(0, M.scope[i].char, char_hl)
         vim.api.nvim_set_hl(0, M.scope[i].underline, { sp = char_hl.fg, underline = true })
     end
+    local current_indent_highlight = config.current_indent.highlight
+    M.current_indent = {}
+    local char_hl = get(current_indent_highlight)
+    if not_set(char_hl) then
+        error(string.format("No highlight group '%s' found", current_indent_highlight))
+    end
+    char_hl.nocombine = true
+    M.current_indent = {
+        char = "@ibl.current_indent.char",
+    }
+    vim.api.nvim_set_hl(0, M.current_indent.char, char_hl)
 end
 
 return M

--- a/lua/ibl/virt_text.lua
+++ b/lua/ibl/virt_text.lua
@@ -44,6 +44,7 @@ end
 ---@param bufnr number
 ---@param row number?
 M.clear_buffer = function(bufnr, row)
+    local namespace_underscore = vim.api.nvim_create_namespace "indent_blankline_underscore"
     local namespace = vim.api.nvim_create_namespace "indent_blankline"
     local line_start = 0
     local line_end = -1
@@ -51,6 +52,7 @@ M.clear_buffer = function(bufnr, row)
         line_start = row - 1
         line_end = row
     end
+    pcall(vim.api.nvim_buf_clear_namespace, bufnr, namespace_underscore, line_start, line_end)
     pcall(vim.api.nvim_buf_clear_namespace, bufnr, namespace, line_start, line_end)
 end
 


### PR DESCRIPTION
Here is an implementation of `current_indent` without using tree sitter. It works on all test cases I tried (though I haven't tried that many), but it is slower than the pure tree sitter stuff. Therefore I have tried to write it in such a way that if you disable it, it should have no noticeable impact on the performance of ibl. 

Would you be open to accepting a pull request similar to this?

(It needs to be cleaned up a bit more. E.g., if you use different `char` symbols, I haven't taken that into account yet. Also, there is some problem with the validation that doesn't work correctly when I edit my own config (it works as expected if I do stuff directly from the ibl files).)