### PR TITLE
fix: ensure full refresh when color scheme changes

### DIFF
--- a/lua/ibl/autocmds.lua
+++ b/lua/ibl/autocmds.lua
@@ -52,7 +52,7 @@ M.setup = function()
         group = group,
         pattern = "*",
         callback = function()
-            highlights.setup()
+            highlights.setup(true)
             ibl.refresh_all()
         end,
     })

--- a/lua/ibl/highlights.lua
+++ b/lua/ibl/highlights.lua
@@ -29,25 +29,25 @@ local not_set = function(hl)
     return not hl or vim.tbl_count(hl) == 0
 end
 
-local setup_builtin_hl_groups = function()
+local setup_builtin_hl_groups = function(force_refresh)
     local whitespace_hl = get "Whitespace"
     local line_nr_hl = get "LineNr"
     local ibl_indent_hl_name = "IblIndent"
     local ibl_whitespace_hl_name = "IblWhitespace"
     local ibl_scope_hl_name = "IblScope"
 
-    if not_set(get(ibl_indent_hl_name)) then
+    if not_set(get(ibl_indent_hl_name)) or force_refresh then
         vim.api.nvim_set_hl(0, ibl_indent_hl_name, whitespace_hl)
     end
-    if not_set(get(ibl_whitespace_hl_name)) then
+    if not_set(get(ibl_whitespace_hl_name)) or force_refresh then
         vim.api.nvim_set_hl(0, ibl_whitespace_hl_name, whitespace_hl)
     end
-    if not_set(get(ibl_scope_hl_name)) then
+    if not_set(get(ibl_scope_hl_name)) or force_refresh then
         vim.api.nvim_set_hl(0, ibl_scope_hl_name, line_nr_hl)
     end
 end
 
-M.setup = function()
+M.setup = function(force_refresh)
     local config = conf.get_config(-1)
 
     for _, fn in
@@ -56,7 +56,7 @@ M.setup = function()
         fn()
     end
 
-    setup_builtin_hl_groups()
+    setup_builtin_hl_groups(force_refresh)
 
     local indent_highlights = config.indent.highlight
     if type(indent_highlights) == "string" then


### PR DESCRIPTION
This commit fixes a bug in the highlight setup in `highlights.lua`. The bug was causing highlights not to refresh when the color scheme is changed. The fix involves introducing an optional `force_refresh` parameter to the `setup` and `setup_builtin_hl_groups` functions. When `force_refresh` is true, the highlights are refreshed even if they are already set.

Alternative Solution:
An alternative solution to this bug could involve extracting the three `vim.api.nvim_set_hl` calls into a new function (e.g., `force_refresh`). This function would be called in the callback of `autocmds.setup` function, ensuring that the highlights are always refreshed when this callback is executed. This approach could potentially make the code more modular and easier to understand, but it would also introduce more changes to the current codebase.