### PR TITLE
Fix typo in highlights.lua

### DIFF
--- a/lua/ibl/highlights.lua
+++ b/lua/ibl/highlights.lua
@@ -19,7 +19,7 @@ local get = function(name)
     -- TODO [Lukas]: remove this when AstroNvim drops support for 0.8
     if not vim.api.nvim_get_hl then
         ---@diagnostic disable-next-line
-        return (vim.fn.hlexists(name) == 1 and vim.api.nvim_get_hl_by_name(name, true)) or vim.empty_dict()
+        return (vim.fn.hlexists(name) == 1 and vim.api.nvim_get_hl_by_name(name, true)) or vim.empty_dict() --[[ @as table ]]
     end
 
     return vim.api.nvim_get_hl(0, { name = name })

--- a/lua/ibl/highlights.lua
+++ b/lua/ibl/highlights.lua
@@ -19,7 +19,7 @@ local get = function(name)
     -- TODO [Lukas]: remove this when AstroNvim drops support for 0.8
     if not vim.api.nvim_get_hl then
         ---@diagnostic disable-next-line
-        return (vim.fn.hlexists(name) == 1 and vim.api.nvim_get_hl_by_name(name, true)) or vim.emtpy_dict()
+        return (vim.fn.hlexists(name) == 1 and vim.api.nvim_get_hl_by_name(name, true)) or vim.empty_dict()
     end
 
     return vim.api.nvim_get_hl(0, { name = name })


### PR DESCRIPTION
Correct 'emtpy_dict()' to 'empty_dict()'.