### PR TITLE
Fix typo that prevents show_end from working as intended

### DIFF
--- a/lua/ibl/init.lua
+++ b/lua/ibl/init.lua
@@ -373,7 +373,7 @@ M.refresh = function(bufnr)
         end
 
         -- Scope end
-        if config.scope.show_end and scope_end and #whitespace_tbl > scope_col_start_single then
+        if config.scope.show_end and scope_end and #whitespace_tbl >= scope_col_start_single then
             vim.api.nvim_buf_set_extmark(bufnr, namespace, row - 1, scope_col_start, {
                 end_col = scope_col_end,
                 hl_group = scope_hl.underline,


### PR DESCRIPTION
Without this fix, the scope_end is not underlined unless you include a space or similar in front of the scope_end line. If the previous behavior is the intended behavior, I think there should be an option so you can get the behavior of this fix.

If we want to avoid highlighting a single parenthesis, we can just check that the length of the scope_end is greater than 1. 

Without fix:

![](https://user-images.githubusercontent.com/7075380/271424999-ca708c53-04cc-4ab8-b0e2-ed11c238fffb.png)


With fix (ignore the white line, that is from the other pull request):

<img width="524" alt="Screenshot 2023-10-06 at 01 05 15" src="https://github.com/lukas-reineke/indent-blankline.nvim/assets/7075380/101386f4-72fb-4f99-a1a6-9f38022ebe8d">

