### PR TITLE
Improve scope highlight hook

### DIFF
--- a/lua/ibl/hooks.lua
+++ b/lua/ibl/hooks.lua
@@ -242,7 +242,7 @@ M.builtin = {
             return scope_index
         end
 
-        -- it is easiest to get correct colors from rainbow-delimiters via
+        -- it is most accurate to get correct colors from rainbow-delimiters via
         -- the scope, since you can have something like:
         -- function()
         --   ...
@@ -265,7 +265,7 @@ M.builtin = {
                 end
             end
         end
-        -- if we can't get highlight correctly by scope, go back to parentheses
+        -- For some languages the scope extends before or after the delimiters. Make an attempt to capture them anyway by looking at the first character of the last line, and the last character of the first line.
         for i, hl_group in ipairs(highlight) do
             if end_pos then
                 for _, extmark in ipairs(end_pos.extmarks) do


### PR DESCRIPTION
It is not always a good idea to pick the highlight color based on the last symbol of the start/end line when using e.g. rainbow-delimiters. E.g. in Lua, I have some functions that look like this: 
```lua
...
... function()
  ...
end,
```
The current code would pick highlights based on the "," (no highlight) and the ")" (wrong highlight, this is one level deeper than `function`-`end`). 

I have had better luck picking based on the actual scope start/end, and then I have left the old last symbol on the start/end line as a fallback. This picks the color from `function` and `end` in the above example. 