### PR TITLE
LuaLS updates to follow style guide + better hl

### DIFF
--- a/lua/ibl/highlights.lua
+++ b/lua/ibl/highlights.lua
@@ -19,7 +19,7 @@ local get = function(name)
     -- TODO [Lukas]: remove this when AstroNvim drops support for 0.8
     if not vim.api.nvim_get_hl then
         ---@diagnostic disable-next-line
-        return (vim.fn.hlexists(name) == 1 and vim.api.nvim_get_hl_by_name(name, true)) or vim.empty_dict() --[[ @as table ]]
+        return (vim.fn.hlexists(name) == 1 and vim.api.nvim_get_hl_by_name(name, true)) or vim.empty_dict() --[[@as table]]
     end
 
     return vim.api.nvim_get_hl(0, { name = name })
@@ -52,7 +52,7 @@ M.setup = function()
     local config = conf.get_config(-1)
 
     for _, fn in
-        pairs(hooks.get(-1, hooks.type.HIGHLIGHT_SETUP) --[[ @as ibl.hooks.cb.highlight_setup[] ]])
+        pairs(hooks.get(-1, hooks.type.HIGHLIGHT_SETUP) --[=[@as ibl.hooks.cb.highlight_setup[]]=])
     do
         fn()
     end

--- a/lua/ibl/init.lua
+++ b/lua/ibl/init.lua
@@ -161,7 +161,7 @@ M.refresh = function(bufnr)
     end
 
     for _, fn in
-        pairs(hooks.get(bufnr, hooks.type.ACTIVE) --[[ @as ibl.hooks.cb.active[] ]])
+        pairs(hooks.get(bufnr, hooks.type.ACTIVE) --[=[@as ibl.hooks.cb.active[]]=])
     do
         if not fn(bufnr) then
             clear_buffer(bufnr)
@@ -178,7 +178,7 @@ M.refresh = function(bufnr)
 
     local scope_disabled = false
     for _, fn in
-        pairs(hooks.get(bufnr, hooks.type.SCOPE_ACTIVE) --[[ @as ibl.hooks.cb.scope_active[] ]])
+        pairs(hooks.get(bufnr, hooks.type.SCOPE_ACTIVE) --[=[@as ibl.hooks.cb.scope_active[]]=])
     do
         if not fn(bufnr) then
             scope_disabled = true
@@ -362,7 +362,7 @@ M.refresh = function(bufnr)
         end
 
         for _, fn in
-            pairs(hooks.get(bufnr, hooks.type.WHITESPACE) --[[ @as ibl.hooks.cb.whitespace[] ]])
+            pairs(hooks.get(bufnr, hooks.type.WHITESPACE) --[=[@as ibl.hooks.cb.whitespace[]]=])
         do
             whitespace_tbl = fn(buffer_state.tick, bufnr, row - 1, whitespace_tbl)
         end
@@ -379,7 +379,7 @@ M.refresh = function(bufnr)
                 return indent.is_indent(w)
             end, whitespace_tbl) + 1
             for _, fn in
-                pairs(hooks.get(bufnr, hooks.type.SCOPE_HIGHLIGHT) --[[ @as ibl.hooks.cb.scope_highlight[] ]])
+                pairs(hooks.get(bufnr, hooks.type.SCOPE_HIGHLIGHT) --[=[@as ibl.hooks.cb.scope_highlight[]]=])
             do
                 scope_index = fn(buffer_state.tick, bufnr, scope, scope_index)
             end
@@ -425,7 +425,7 @@ M.refresh = function(bufnr)
         end
 
         for _, fn in
-            pairs(hooks.get(bufnr, hooks.type.VIRTUAL_TEXT) --[[ @as ibl.hooks.cb.virtual_text[] ]])
+            pairs(hooks.get(bufnr, hooks.type.VIRTUAL_TEXT) --[=[@as ibl.hooks.cb.virtual_text[]]=])
         do
             virt_text = fn(buffer_state.tick, bufnr, row - 1, virt_text)
         end


### PR DESCRIPTION
This updates the `@as` type annotations to follow: https://luals.github.io/wiki/annotations/#as

This also improves highlighting like seen here:

After update:
<img width="378" alt="Screenshot 2023-10-23 at 00 09 59" src="https://github.com/lukas-reineke/indent-blankline.nvim/assets/7075380/f256bdee-12e2-46e7-b383-c237e9e7f924">

Before update:
<img width="372" alt="Screenshot 2023-10-23 at 00 10 09" src="https://github.com/lukas-reineke/indent-blankline.nvim/assets/7075380/da14b2b3-aeb0-4d09-9c3d-a45e2a009141">

