### PR TITLE
fix: config overwrite

### DIFF
--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -290,12 +290,12 @@ end
 
 --- Overwrites the global configuration
 ---
---- Same as `set_config`, but all list values are overwritten instead of merged
+--- Same as `update_config`, but all list values are overwritten instead of merged
 ---@param config ibl.config
 ---@return ibl.config.full
 M.overwrite_config = function(config)
     validate_config(config)
-    M.config = merge_configs("overwrite", M.default_config, config)
+    M.config = merge_configs("overwrite", M.config or M.default_config, config)
 
     return M.config
 end


### PR DESCRIPTION
The documentation was not consistent with the code and comments. I think the version that is described in the documentation is more useful, so this should be what the code does.

I think it is fair to classify this as a bug, so this is not a breaking change. But it does behave differently now. If you want the old behavior, call `ibl.setup` once before.