### PR TITLE
fix: set_config

### DIFF
--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -271,7 +271,7 @@ end
 ---@return ibl.config.full
 M.set_config = function(config)
     validate_config(config)
-    M.config = merge_configs("merge", M.default_config, config)
+    M.config = merge_configs("merge", M.config or M.default_config, config)
 
     return M.config
 end


### PR DESCRIPTION
This code fixes the problem I mention with `ibl.overwrite()` in #778. With this bug fix I get the expected behavior mentioned in that issue. (This also closes that issue, since I get the behavior I was asking for.)