### PR TITLE
fix: move some scope calculations out of main loop

### DIFF
--- a/doc/indent_blankline.txt
+++ b/doc/indent_blankline.txt
@@ -231,10 +231,13 @@ config.viewport_buffer                            *ibl.config.viewport_buffer*
             Default: `30` ~
 
                                               *ibl.config.viewport_buffer.max*
-   • {max}  (number)
+   • {max}  (number) [deprecated]
             Maximum number of lines above and below of what is currently
             visible in the window for which indentation guides will
             be generated
+
+            (This functionality has been deprecated, and the exact offset
+            can be chosen with `min` instead)
 
             Default: `500` ~
 

--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -21,7 +21,7 @@ M.default_config = {
     debounce = 200,
     viewport_buffer = {
         min = 30,
-        max = 500,
+        max = 60,
     },
     indent = {
         char = "▎",

--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -21,7 +21,7 @@ M.default_config = {
     debounce = 200,
     viewport_buffer = {
         min = 30,
-        max = 60,
+        max = 500,
     },
     indent = {
         char = "▎",

--- a/lua/ibl/init.lua
+++ b/lua/ibl/init.lua
@@ -193,9 +193,8 @@ M.refresh = function(bufnr)
         if scope and scope:start() >= 0 then
             local scope_start = scope:start()
             local scope_end = scope:end_()
-            offset = top_offset - math.min(top_offset - math.min(offset, scope_start), config.viewport_buffer.max)
-            scope_start_line = vim.api.nvim_buf_get_lines(bufnr, scope_start, scope_start + 1, false)
-            scope_end_line = vim.api.nvim_buf_get_lines(bufnr, scope_end, scope_end + 1, false)
+            scope_start_line = vim.api.nvim_buf_get_lines(bufnr, scope_start, scope_start + 1, false)[1]
+            scope_end_line = vim.api.nvim_buf_get_lines(bufnr, scope_end, scope_end + 1, false)[1]
         end
     end
 
@@ -267,32 +266,30 @@ M.refresh = function(bufnr)
 
     if scope and scope_start_line then
         -- find whitespace tables for the start and end lines of scope
-        local whitespace_start = utils.get_whitespace(scope_start_line[1])
-        local whitespace_end = utils.get_whitespace(scope_end_line[1])
+        local whitespace_start = utils.get_whitespace(scope_start_line)
+        local whitespace_end = utils.get_whitespace(scope_end_line)
         local whitespace_tbl_start = indent.get(whitespace_start, indent_opts, nil)
         local whitespace_tbl_end = indent.get(whitespace_end, indent_opts, nil)
-        local whitespace, whitespace_tbl
+        local whitespace, whitespace_tbl, scope_row
         -- use the smallest whitespace table of the two to determine the scope index
         if #whitespace_tbl_end < #whitespace_tbl_start then
             whitespace = whitespace_end
             whitespace_tbl = whitespace_tbl_end
+            scope_row = scope_row_end
         else
             whitespace = whitespace_start
             whitespace_tbl = whitespace_tbl_start
+            scope_row = scope_row_start
         end
 
         -- do the same calculations as in the main loop below, but note that the scope
         -- start and end will never be on a blankline, so these cases simplify a lot
-        local current_left_offset = left_offset
-        while #whitespace_tbl > 0 and current_left_offset > 0 do
-            table.remove(whitespace_tbl, 1)
-            current_left_offset = current_left_offset - 1
-        end
+        whitespace_tbl = utils.fix_horizontal_scroll(whitespace_tbl, left_offset)
 
         for _, fn in
             pairs(hooks.get(bufnr, hooks.type.WHITESPACE) --[=[@as ibl.hooks.cb.whitespace[]]=])
         do
-            whitespace_tbl = fn(buffer_state.tick, bufnr, scope_row_start - 1, whitespace_tbl)
+            whitespace_tbl = fn(buffer_state.tick, bufnr, scope_row - 1, whitespace_tbl)
         end
 
         -- calculate the scope index
@@ -406,11 +403,7 @@ M.refresh = function(bufnr)
         end
 
         -- Fix horizontal scroll
-        local current_left_offset = left_offset
-        while #whitespace_tbl > 0 and current_left_offset > 0 do
-            table.remove(whitespace_tbl, 1)
-            current_left_offset = current_left_offset - 1
-        end
+        whitespace_tbl = utils.fix_horizontal_scroll(whitespace_tbl, left_offset)
 
         for _, fn in
             pairs(hooks.get(bufnr, hooks.type.WHITESPACE) --[=[@as ibl.hooks.cb.whitespace[]]=])

--- a/lua/ibl/init.lua
+++ b/lua/ibl/init.lua
@@ -187,10 +187,15 @@ M.refresh = function(bufnr)
     end
 
     local scope
+    local scope_start_line, scope_end_line
     if not scope_disabled and config.scope.enabled then
         scope = scp.get(bufnr, config)
         if scope and scope:start() >= 0 then
-            offset = top_offset - math.min(top_offset - math.min(offset, scope:start()), config.viewport_buffer.max)
+            local scope_start = scope:start()
+            local scope_end = scope:end_()
+            offset = top_offset - math.min(top_offset - math.min(offset, scope_start), config.viewport_buffer.max)
+            scope_start_line = vim.api.nvim_buf_get_lines(bufnr, scope_start, scope_start + 1, false)
+            scope_end_line = vim.api.nvim_buf_get_lines(bufnr, scope_end, scope_end + 1, false)
         end
     end
 
@@ -257,6 +262,49 @@ M.refresh = function(bufnr)
                 line_skipped[i] = true
                 break
             end
+        end
+    end
+
+    if scope and scope_start_line then
+        -- find whitespace tables for the start and end lines of scope
+        local whitespace_start = utils.get_whitespace(scope_start_line[1])
+        local whitespace_end = utils.get_whitespace(scope_end_line[1])
+        local whitespace_tbl_start = indent.get(whitespace_start, indent_opts, nil)
+        local whitespace_tbl_end = indent.get(whitespace_end, indent_opts, nil)
+        local whitespace, whitespace_tbl
+        -- use the smallest whitespace table of the two to determine the scope index
+        if #whitespace_tbl_end < #whitespace_tbl_start then
+            whitespace = whitespace_end
+            whitespace_tbl = whitespace_tbl_end
+        else
+            whitespace = whitespace_start
+            whitespace_tbl = whitespace_tbl_start
+        end
+
+        -- do the same calculations as in the main loop below, but note that the scope
+        -- start and end will never be on a blankline, so these cases simplify a lot
+        local current_left_offset = left_offset
+        while #whitespace_tbl > 0 and current_left_offset > 0 do
+            table.remove(whitespace_tbl, 1)
+            current_left_offset = current_left_offset - 1
+        end
+
+        for _, fn in
+            pairs(hooks.get(bufnr, hooks.type.WHITESPACE) --[=[@as ibl.hooks.cb.whitespace[]]=])
+        do
+            whitespace_tbl = fn(buffer_state.tick, bufnr, scope_row_start - 1, whitespace_tbl)
+        end
+
+        -- calculate the scope index
+        scope_col_start = #whitespace
+        scope_col_start_single = #whitespace_tbl
+        scope_index = #utils.tbl_filter(function(w)
+            return indent.is_indent(w)
+        end, whitespace_tbl) + 1
+        for _, fn in
+            pairs(hooks.get(bufnr, hooks.type.SCOPE_HIGHLIGHT) --[=[@as ibl.hooks.cb.scope_highlight[]]=])
+        do
+            scope_index = fn(buffer_state.tick, bufnr, scope, scope_index)
         end
     end
 
@@ -375,18 +423,6 @@ M.refresh = function(bufnr)
         -- #### make virtual text ####
         local scope_start = row == scope_row_start
         local scope_end = row == scope_row_end
-        if scope_start and scope then
-            scope_col_start = #whitespace
-            scope_col_start_single = #whitespace_tbl
-            scope_index = #utils.tbl_filter(function(w)
-                return indent.is_indent(w)
-            end, whitespace_tbl) + 1
-            for _, fn in
-                pairs(hooks.get(bufnr, hooks.type.SCOPE_HIGHLIGHT) --[=[@as ibl.hooks.cb.scope_highlight[]]=])
-            do
-                scope_index = fn(buffer_state.tick, bufnr, scope, scope_index)
-            end
-        end
 
         local whitespace_only = not blankline and line == whitespace
         local char_map = vt.get_char_map(config, listchars, whitespace_only, blankline)

--- a/lua/ibl/utils.lua
+++ b/lua/ibl/utils.lua
@@ -348,4 +348,16 @@ M.tbl_get_index = function(list, i)
     return list[((i - 1) % #list) + 1]
 end
 
+---@param whitespace_tbl ibl.indent.whitespace[]
+---@param left_offset number
+---@return ibl.indent.whitespace[]
+M.fix_horizontal_scroll = function(whitespace_tbl, left_offset)
+    local current_left_offset = left_offset
+    while #whitespace_tbl > 0 and current_left_offset > 0 do
+        table.remove(whitespace_tbl, 1)
+        current_left_offset = current_left_offset - 1
+    end
+    return whitespace_tbl
+end
+
 return M


### PR DESCRIPTION
This pull request moves the calculation of the scope index out of the main loop, since we want to be able to figure this out without including lines all the way from the start of the scope if we are in the middle of a very long scope. 

Since we no longer need to include as many lines to get good highlighting, I also lowered the default value of `viewport_buffer.max` from 500 to 60. I think we can lower both `min` and `max` even more, but at that point it becomes a question of personal preference. I picked 60, since that should about cover one full screen for most people (I think?). 

Furthermore, I added a comparison between the start line and end line whitespace tables, and we use the smaller one to calculate the scope index. This fixes #752, and I can't think of any normal formatting style that will get worse highlighting by this. If you want, I can include an option for whether to use the start (of the scope), end or the minimum of both?