### PR TITLE
fix: typo in `arduino`

### DIFF
--- a/lua/ibl/scope_languages.lua
+++ b/lua/ibl/scope_languages.lua
@@ -643,7 +643,7 @@ M.cpp = vim.tbl_extend("keep", M.c, {
     catch_clause = true,
     requires_expression = true,
 })
-M.arduion = M.cpp
+M.arduino = M.cpp
 M.cuda = M.cpp
 M.astro = M.html
 M.glsl = M.c


### PR DESCRIPTION
Since I was already making the other pull request, I thought I might as well add this one too. See: #763