### PR TITLE
Added language: risor

### DIFF
--- a/lua/ibl/scope_languages.lua
+++ b/lua/ibl/scope_languages.lua
@@ -416,6 +416,13 @@ local M = {
     re2c = {
         body = true,
     },
+    risor = {
+        function_declaration = true,
+        if_statement = true,
+        block = true,
+        switch_statement = true,
+        for_statement = true,
+    },
     ron = {
         array = true,
         map = true,


### PR DESCRIPTION
Adds language `risor`: <https://risor.io/>

I'm currently creating a tree-sitter grammar for it: <https://github.com/applejag/tree-sitter-risor>

Took me a while of debugging why the scope feature didn't work out-of-the box. I thought for so long that my grammar was wrong 😅 never considered that it was ibl

I was not able to add the language just from configs though. Would've been nice if that was possible. But currently ibl just skips if it does not contian the language in its hardcoded list:

https://github.com/lukas-reineke/indent-blankline.nvim/blob/d4c718467d35bc93714425a7102d82e7e5065280/lua/ibl/scope.lua#L60-L63
