### PR TITLE
feat: improve scope detection and calculation

### DIFF
--- a/lua/ibl/init.lua
+++ b/lua/ibl/init.lua
@@ -189,7 +189,7 @@ M.refresh = function(bufnr)
     local scope
     local scope_start_line, scope_end_line
     if not scope_disabled and config.scope.enabled then
-        scope = scp.get(bufnr, config)
+        scope = scp.get(bufnr, config, global_buffer_state[bufnr] or {})
         if scope and scope:start() >= 0 then
             local scope_start = scope:start()
             local scope_end = scope:end_()

--- a/lua/ibl/scope.lua
+++ b/lua/ibl/scope.lua
@@ -4,10 +4,11 @@ local M = {}
 
 ---@param win number
 ---@return table<number, number>
-M.get_cursor_range = function(win)
+---@return table<number, number>
+M.get_cursor_ranges = function(win)
     local pos = vim.api.nvim_win_get_cursor(win)
     local row, col = pos[1] - 1, pos[2]
-    return { row, 0, row, col }
+    return { row, 0, row, col }, { row, col, row, col }
 end
 
 --- Takes a language tree and a range, and returns the child language tree for that range
@@ -34,8 +35,9 @@ end
 
 ---@param bufnr number
 ---@param config ibl.config.full
+---@param buffer_state { scope: TSNode?, left_offset: number, top_offset: number, tick: number }
 ---@return TSNode?
-M.get = function(bufnr, config)
+M.get = function(bufnr, config, buffer_state)
     local lang_tree_ok, lang_tree = pcall(vim.treesitter.get_parser, bufnr)
     if not lang_tree_ok or not lang_tree then
         return nil
@@ -51,7 +53,7 @@ M.get = function(bufnr, config)
         win = 0
     end
 
-    local range = M.get_cursor_range(win)
+    local range, cursor_range = M.get_cursor_ranges(win)
     lang_tree = M.language_for_range(lang_tree, range, config)
     if not lang_tree then
         return nil
@@ -62,9 +64,14 @@ M.get = function(bufnr, config)
         return nil
     end
 
-    local node = lang_tree:named_node_for_range(range, { bufnr = bufnr })
+    local node = lang_tree:named_node_for_range(cursor_range, { bufnr = bufnr })
     if not node then
         return nil
+    end
+
+    -- if the scope didn't change, return node immediately
+    if buffer_state.scope and buffer_state.scope:equal(node) then
+        return node
     end
 
     local excluded_node_types =


### PR DESCRIPTION
This uses the exact cursor position to find the treesitter node used when finding the scope, which improves scope detection in Python:

<img width="879" alt="Screenshot 2023-12-21 at 17 47 25" src="https://github.com/lukas-reineke/indent-blankline.nvim/assets/7075380/c757ce63-5b5b-4dfc-b97b-3bdbf1efa4af">

<img width="880" alt="Screenshot 2023-12-21 at 17 47 40" src="https://github.com/lukas-reineke/indent-blankline.nvim/assets/7075380/ccbbae71-9b7b-4490-9f63-be21adf5a95e">

Importantly, it doesn't change the `language_for_range` calculation, which from what I can tell is the reason the other range was starting at column 0 of the current row. 

I also added an early exit of the scope calculation if the node didn't change (`TSNode:equal(TSNode)` tests that the tree and id are equal), so we can skip the slightly slower calculations after that step (joining and going through tables). This should slightly speed up the calculation in a lot of cases (given all the auto commands used), but it is less important than the other change.

This should close #799. 