### PR TITLE
fix: scope start padding

### DIFF
--- a/lua/ibl/init.lua
+++ b/lua/ibl/init.lua
@@ -419,8 +419,16 @@ M.refresh = function(bufnr)
 
         local whitespace_only = not blankline and line == whitespace
         local char_map = vt.get_char_map(config, listchars, whitespace_only, blankline)
-        local virt_text, scope_hl =
-            vt.get(config, char_map, whitespace_tbl, scope_active, scope_index, scope_end, scope_col_start_single)
+        local virt_text, scope_hl = vt.get(
+            config,
+            char_map,
+            whitespace_tbl,
+            scope_active,
+            scope_index,
+            scope_start,
+            scope_end,
+            scope_col_start_single
+        )
 
         -- #### set virtual text ####
         vt.clear_buffer(bufnr, row)

--- a/lua/ibl/virt_text.lua
+++ b/lua/ibl/virt_text.lua
@@ -59,13 +59,26 @@ end
 ---@param whitespace_tbl ibl.indent.whitespace[]
 ---@param scope_active boolean
 ---@param scope_index number
+---@param scope_start boolean
 ---@param scope_end boolean
 ---@param scope_col_start_single number
 ---@return ibl.virtual_text, ibl.highlight
-M.get = function(config, char_map, whitespace_tbl, scope_active, scope_index, scope_end, scope_col_start_single)
+M.get = function(
+    config,
+    char_map,
+    whitespace_tbl,
+    scope_active,
+    scope_index,
+    scope_start,
+    scope_end,
+    scope_col_start_single
+)
     local scope_hl = utils.tbl_get_index(highlights.scope, scope_index)
     local indent_index = 1
     local virt_text = {}
+    local scope_edge = (config.scope.show_start and scope_start and not config.scope.show_exact_scope)
+        or (config.scope.show_end and scope_end)
+
     for i, ws in ipairs(whitespace_tbl) do
         local whitespace_hl = utils.tbl_get_index(highlights.whitespace, indent_index - 1).char
         local indent_hl
@@ -84,22 +97,24 @@ M.get = function(config, char_map, whitespace_tbl, scope_active, scope_index, sc
             indent_index = indent_index + 1
         end
 
-        if config.scope.show_end and sa and scope_end and i - 1 > scope_col_start_single then
+        if sa and scope_edge and i - 1 > scope_col_start_single then
             scope_hl = utils.tbl_get_index(highlights.scope, scope_index)
             underline_hl = scope_hl.underline
         end
 
         if sa and i - 1 == scope_col_start_single then
-            indent_hl = scope_hl.char
+            if not scope_start then
+                indent_hl = scope_hl.char
 
-            if config.scope.char then
-                local scope_char = get_char(config.scope.char, scope_index)
-                if vim.fn.strdisplaywidth(scope_char) == 1 then
-                    char = scope_char
+                if config.scope.char then
+                    local scope_char = get_char(config.scope.char, scope_index)
+                    if vim.fn.strdisplaywidth(scope_char) == 1 then
+                        char = scope_char
+                    end
                 end
             end
 
-            if config.scope.show_end and scope_end then
+            if scope_edge then
                 underline_hl = scope_hl.underline
             end
         end

--- a/specs/features/virt_text_spec.lua
+++ b/specs/features/virt_text_spec.lua
@@ -280,11 +280,20 @@ describe("virt_text", function()
         local whitespace_tbl = {}
         local scope_active = false
         local scope_index = -1
+        local scope_start = false
         local scope_end = false
         local scope_col_start_single = 0
 
-        local virt_text =
-            vt.get(config, char_map, whitespace_tbl, scope_active, scope_index, scope_end, scope_col_start_single)
+        local virt_text = vt.get(
+            config,
+            char_map,
+            whitespace_tbl,
+            scope_active,
+            scope_index,
+            scope_start,
+            scope_end,
+            scope_col_start_single
+        )
 
         assert.are.same(virt_text, {})
     end)
@@ -303,11 +312,20 @@ describe("virt_text", function()
         local whitespace_tbl = { INDENT, SPACE, INDENT, SPACE }
         local scope_active = false
         local scope_index = -1
+        local scope_start = false
         local scope_end = false
         local scope_col_start_single = 0
 
-        local virt_text =
-            vt.get(config, char_map, whitespace_tbl, scope_active, scope_index, scope_end, scope_col_start_single)
+        local virt_text = vt.get(
+            config,
+            char_map,
+            whitespace_tbl,
+            scope_active,
+            scope_index,
+            scope_start,
+            scope_end,
+            scope_col_start_single
+        )
 
         assert.are.same(virt_text, {
             { "f", { "@ibl.whitespace.char.1", "@ibl.indent.char.1" } },
@@ -331,11 +349,20 @@ describe("virt_text", function()
         local whitespace_tbl = { INDENT, SPACE, INDENT, SPACE, INDENT, SPACE }
         local scope_active = false
         local scope_index = -1
+        local scope_start = false
         local scope_end = false
         local scope_col_start_single = 0
 
-        local virt_text =
-            vt.get(config, char_map, whitespace_tbl, scope_active, scope_index, scope_end, scope_col_start_single)
+        local virt_text = vt.get(
+            config,
+            char_map,
+            whitespace_tbl,
+            scope_active,
+            scope_index,
+            scope_start,
+            scope_end,
+            scope_col_start_single
+        )
 
         assert.are.same(virt_text, {
             { "a", { "@ibl.whitespace.char.1", "@ibl.indent.char.1" } },
@@ -361,11 +388,20 @@ describe("virt_text", function()
         local whitespace_tbl = { TAB_START, TAB_END, TAB_START, TAB_END, TAB_START, TAB_END }
         local scope_active = false
         local scope_index = -1
+        local scope_start = false
         local scope_end = false
         local scope_col_start_single = 0
 
-        local virt_text =
-            vt.get(config, char_map, whitespace_tbl, scope_active, scope_index, scope_end, scope_col_start_single)
+        local virt_text = vt.get(
+            config,
+            char_map,
+            whitespace_tbl,
+            scope_active,
+            scope_index,
+            scope_start,
+            scope_end,
+            scope_col_start_single
+        )
 
         assert.are.same(virt_text, {
             { "a", { "@ibl.whitespace.char.1", "@ibl.indent.char.1" } },
@@ -391,11 +427,20 @@ describe("virt_text", function()
         local whitespace_tbl = { INDENT, SPACE, INDENT, SPACE }
         local scope_active = false
         local scope_index = -1
+        local scope_start = false
         local scope_end = false
         local scope_col_start_single = 0
 
-        local virt_text =
-            vt.get(config, char_map, whitespace_tbl, scope_active, scope_index, scope_end, scope_col_start_single)
+        local virt_text = vt.get(
+            config,
+            char_map,
+            whitespace_tbl,
+            scope_active,
+            scope_index,
+            scope_start,
+            scope_end,
+            scope_col_start_single
+        )
 
         assert.are.same(virt_text, {
             { "e", { "@ibl.whitespace.char.1" } },
@@ -419,11 +464,20 @@ describe("virt_text", function()
         local whitespace_tbl = { INDENT, SPACE, INDENT, SPACE }
         local scope_active = true
         local scope_index = 1
+        local scope_start = false
         local scope_end = false
         local scope_col_start_single = 2
 
-        local virt_text =
-            vt.get(config, char_map, whitespace_tbl, scope_active, scope_index, scope_end, scope_col_start_single)
+        local virt_text = vt.get(
+            config,
+            char_map,
+            whitespace_tbl,
+            scope_active,
+            scope_index,
+            scope_start,
+            scope_end,
+            scope_col_start_single
+        )
 
         assert.are.same(virt_text, {
             { "f", { "@ibl.whitespace.char.1", "@ibl.indent.char.1" } },
@@ -447,11 +501,20 @@ describe("virt_text", function()
         local whitespace_tbl = { TAB_START, TAB_FILL, TAB_FILL, TAB_END, TAB_START_SINGLE }
         local scope_active = false
         local scope_index = -1
+        local scope_start = false
         local scope_end = false
         local scope_col_start_single = 0
 
-        local virt_text =
-            vt.get(config, char_map, whitespace_tbl, scope_active, scope_index, scope_end, scope_col_start_single)
+        local virt_text = vt.get(
+            config,
+            char_map,
+            whitespace_tbl,
+            scope_active,
+            scope_index,
+            scope_start,
+            scope_end,
+            scope_col_start_single
+        )
 
         assert.are.same(virt_text, {
             { "a", { "@ibl.whitespace.char.1", "@ibl.indent.char.1" } },
@@ -479,11 +542,20 @@ describe("virt_text", function()
         local whitespace_tbl = { INDENT, SPACE, INDENT, SPACE, INDENT, SPACE }
         local scope_active = false
         local scope_index = -1
+        local scope_start = false
         local scope_end = false
         local scope_col_start_single = 0
 
-        local virt_text =
-            vt.get(config, char_map, whitespace_tbl, scope_active, scope_index, scope_end, scope_col_start_single)
+        local virt_text = vt.get(
+            config,
+            char_map,
+            whitespace_tbl,
+            scope_active,
+            scope_index,
+            scope_start,
+            scope_end,
+            scope_col_start_single
+        )
 
         assert.are.same(virt_text, {
             { "f", { "@ibl.whitespace.char.1", "@ibl.indent.char.1" } },
@@ -513,11 +585,20 @@ describe("virt_text", function()
         local whitespace_tbl = { INDENT, SPACE, INDENT, SPACE, INDENT, SPACE }
         local scope_active = true
         local scope_index = 2
+        local scope_start = false
         local scope_end = false
         local scope_col_start_single = 2
 
-        local virt_text =
-            vt.get(config, char_map, whitespace_tbl, scope_active, scope_index, scope_end, scope_col_start_single)
+        local virt_text = vt.get(
+            config,
+            char_map,
+            whitespace_tbl,
+            scope_active,
+            scope_index,
+            scope_start,
+            scope_end,
+            scope_col_start_single
+        )
 
         assert.are.same(virt_text, {
             { "f", { "@ibl.whitespace.char.1", "@ibl.indent.char.1" } },
@@ -547,16 +628,68 @@ describe("virt_text", function()
         local whitespace_tbl = { INDENT, SPACE, INDENT, SPACE, INDENT, SPACE }
         local scope_active = true
         local scope_index = 2
+        local scope_start = false
         local scope_end = true
         local scope_col_start_single = 2
 
-        local virt_text =
-            vt.get(config, char_map, whitespace_tbl, scope_active, scope_index, scope_end, scope_col_start_single)
+        local virt_text = vt.get(
+            config,
+            char_map,
+            whitespace_tbl,
+            scope_active,
+            scope_index,
+            scope_start,
+            scope_end,
+            scope_col_start_single
+        )
 
         assert.are.same(virt_text, {
             { "f", { "@ibl.whitespace.char.1", "@ibl.indent.char.1" } },
             { "e", { "@ibl.whitespace.char.1" } },
             { "f", { "@ibl.whitespace.char.2", "@ibl.scope.char.2", "@ibl.scope.underline.2" } },
+            { "e", { "@ibl.whitespace.char.2", "@ibl.scope.underline.2" } },
+            { "f", { "@ibl.whitespace.char.3", "@ibl.indent.char.3", "@ibl.scope.underline.2" } },
+            { "e", { "@ibl.whitespace.char.3", "@ibl.scope.underline.2" } },
+        })
+    end)
+
+    it("handles multiple highlight groups with scope on scope start", function()
+        local config = conf.set_config {
+            whitespace = { highlight = { "Error", "Function", "Label" } },
+            indent = { highlight = { "Error", "Function", "Label" } },
+            scope = { highlight = { "Error", "Function", "Label" } },
+        }
+        highlights.setup()
+        local char_map = {
+            [TAB_START] = "a",
+            [TAB_START_SINGLE] = "b",
+            [TAB_FILL] = "c",
+            [TAB_END] = "d",
+            [SPACE] = "e",
+            [INDENT] = "f",
+        }
+        local whitespace_tbl = { INDENT, SPACE, INDENT, SPACE, INDENT, SPACE }
+        local scope_active = true
+        local scope_index = 2
+        local scope_start = true
+        local scope_end = false
+        local scope_col_start_single = 2
+
+        local virt_text = vt.get(
+            config,
+            char_map,
+            whitespace_tbl,
+            scope_active,
+            scope_index,
+            scope_start,
+            scope_end,
+            scope_col_start_single
+        )
+
+        assert.are.same(virt_text, {
+            { "f", { "@ibl.whitespace.char.1", "@ibl.indent.char.1" } },
+            { "e", { "@ibl.whitespace.char.1" } },
+            { "f", { "@ibl.whitespace.char.2", "@ibl.indent.char.2", "@ibl.scope.underline.2" } },
             { "e", { "@ibl.whitespace.char.2", "@ibl.scope.underline.2" } },
             { "f", { "@ibl.whitespace.char.3", "@ibl.indent.char.3", "@ibl.scope.underline.2" } },
             { "e", { "@ibl.whitespace.char.3", "@ibl.scope.underline.2" } },


### PR DESCRIPTION
With the changes of #795, the scope indent and the scope start line indent are not necessarily the same anymore. The scope start underline padding needs to take this into account.

Without fix:
![2023-12-22_10-30](https://github.com/lukas-reineke/indent-blankline.nvim/assets/12900252/90aaa633-1db3-49dc-a961-c880c558cc1a)

With fix:
![2023-12-22_10-29](https://github.com/lukas-reineke/indent-blankline.nvim/assets/12900252/a0af7bcf-e0ef-4b8c-8d92-986e94b6886a)