### PR TITLE
fix: remove starlark top level scope

### DIFF
--- a/lua/ibl/scope_languages.lua
+++ b/lua/ibl/scope_languages.lua
@@ -497,7 +497,6 @@ local M = {
         catch_statement = true,
     },
     starlark = {
-        module = true,
         function_definition = true,
         dictionary_comprehension = true,
         list_comprehension = true,


### PR DESCRIPTION
From what I can tell this change should have been included in https://github.com/lukas-reineke/indent-blankline.nvim/commit/9301e434dd41154ffe5c3d5b8a5c9acd075ebeff since `module` seems to be the top level scope in starlark.