### PR TITLE
fix: remove top level scopes

### DIFF
--- a/lua/ibl/scope_languages.lua
+++ b/lua/ibl/scope_languages.lua
@@ -497,7 +497,6 @@ local M = {
         catch_statement = true,
     },
     starlark = {
-        module = true,
         function_definition = true,
         dictionary_comprehension = true,
         list_comprehension = true,
@@ -625,7 +624,6 @@ local M = {
         block = true,
     },
     yaml = {
-        stream = true,
         block_node = true,
     },
     yuck = {


### PR DESCRIPTION
This removes the top level scopes for starlark and yaml, since they cause problems when scope highlighting.

Note: `chunk` is also a top level scope for Lua, but with the Lua parser `chunk` doesn't seem to cause any problems. 