### PR TITLE
feat: add git_config to scope_languages

### DIFF
--- a/lua/ibl/scope_languages.lua
+++ b/lua/ibl/scope_languages.lua
@@ -173,6 +173,9 @@ local M = {
         get_body = true,
         set_body = true,
     },
+    git_config = {
+        section = true,
+    },
     gleam = {
         function_body = true,
         case_clause = true,


### PR DESCRIPTION
This adds git_config to scope_languages. From what I can tell `section` is the only scope (the format is pretty simple).