### PR TITLE
Temporary fix: eliminating the missing key 'virt_text_repeat_linebreak'

### DIFF
--- a/lua/ibl/init.lua
+++ b/lua/ibl/init.lua
@@ -161,7 +161,7 @@ M.refresh = function(bufnr)
     end
 
     for _, fn in
-        pairs(hooks.get(bufnr, hooks.type.ACTIVE) --[=[@as ibl.hooks.cb.active[]]=])
+    pairs(hooks.get(bufnr, hooks.type.ACTIVE) --[=[@as ibl.hooks.cb.active[]]=])
     do
         if not fn(bufnr) then
             clear_buffer(bufnr)
@@ -178,7 +178,7 @@ M.refresh = function(bufnr)
 
     local scope_disabled = false
     for _, fn in
-        pairs(hooks.get(bufnr, hooks.type.SCOPE_ACTIVE) --[=[@as ibl.hooks.cb.scope_active[]]=])
+    pairs(hooks.get(bufnr, hooks.type.SCOPE_ACTIVE) --[=[@as ibl.hooks.cb.scope_active[]]=])
     do
         if not fn(bufnr) then
             scope_disabled = true
@@ -287,7 +287,7 @@ M.refresh = function(bufnr)
         whitespace_tbl = utils.fix_horizontal_scroll(whitespace_tbl, left_offset)
 
         for _, fn in
-            pairs(hooks.get(bufnr, hooks.type.WHITESPACE) --[=[@as ibl.hooks.cb.whitespace[]]=])
+        pairs(hooks.get(bufnr, hooks.type.WHITESPACE) --[=[@as ibl.hooks.cb.whitespace[]]=])
         do
             whitespace_tbl = fn(buffer_state.tick, bufnr, scope_row - 1, whitespace_tbl)
         end
@@ -299,7 +299,7 @@ M.refresh = function(bufnr)
             return indent.is_indent(w)
         end, whitespace_tbl) + 1
         for _, fn in
-            pairs(hooks.get(bufnr, hooks.type.SCOPE_HIGHLIGHT) --[=[@as ibl.hooks.cb.scope_highlight[]]=])
+        pairs(hooks.get(bufnr, hooks.type.SCOPE_HIGHLIGHT) --[=[@as ibl.hooks.cb.scope_highlight[]]=])
         do
             scope_index = fn(buffer_state.tick, bufnr, scope, scope_index)
         end
@@ -409,7 +409,7 @@ M.refresh = function(bufnr)
         whitespace_tbl = utils.fix_horizontal_scroll(whitespace_tbl, left_offset)
 
         for _, fn in
-            pairs(hooks.get(bufnr, hooks.type.WHITESPACE) --[=[@as ibl.hooks.cb.whitespace[]]=])
+        pairs(hooks.get(bufnr, hooks.type.WHITESPACE) --[=[@as ibl.hooks.cb.whitespace[]]=])
         do
             whitespace_tbl = fn(buffer_state.tick, bufnr, row - 1, whitespace_tbl)
         end
@@ -468,7 +468,7 @@ M.refresh = function(bufnr)
         end
 
         for _, fn in
-            pairs(hooks.get(bufnr, hooks.type.VIRTUAL_TEXT) --[=[@as ibl.hooks.cb.virtual_text[]]=])
+        pairs(hooks.get(bufnr, hooks.type.VIRTUAL_TEXT) --[=[@as ibl.hooks.cb.virtual_text[]]=])
         do
             virt_text = fn(buffer_state.tick, bufnr, row - 1, virt_text)
         end
@@ -478,7 +478,7 @@ M.refresh = function(bufnr)
             vim.api.nvim_buf_set_extmark(bufnr, namespace, row - 1, 0, {
                 virt_text = virt_text,
                 virt_text_pos = "overlay",
-                virt_text_repeat_linebreak = repeat_indent or nil,
+                -- virt_text_repeat_linebreak = repeat_indent or nil,
                 hl_mode = "combine",
                 priority = config.indent.priority,
                 strict = false,


### PR DESCRIPTION
After the last update throws an exception on every cursor move. Disabling the missing key seems works fine - don't know what is it for, sorry. Maybe it'll be helpful.