### PR TITLE
fix: only use `vim.iter` if available to avoid accidental breaking change

### DIFF
--- a/lua/ibl/utils.lua
+++ b/lua/ibl/utils.lua
@@ -425,7 +425,8 @@ end
 ---@vararg T
 ---@return T
 M.tbl_join = function(...)
-    return vim.iter({ ... }):flatten():totable()
+    ---@diagnostic disable-next-line: deprecated
+    return vim.iter and vim.iter({ ... }):flatten():totable() or vim.tbl_flatten { ... }
 end
 
 ---@generic T


### PR DESCRIPTION
v3.6.0's release had a breaking change when it changed what version of neovim it supported. This reverts the breaking change if using an older version of neovim but still uses the new, non-deprecated API if it's available. This is particularly important immediately after a release because package managers haven't all caught up to providing 0.10 and it may not be widely available or even used in stable environments until the first path release. I think if we don't want to merge this we should at least revert the v3.6.0 release and tag v4 to indicate the breaking nature of the release.


Thanks so much for all your effort supporting and developing this great plugin!