### PR TITLE
fix: highlights.lua setup builtin hl groups for all Ibl names

### DIFF
--- a/lua/ibl/highlights.lua
+++ b/lua/ibl/highlights.lua
@@ -28,9 +28,12 @@ end
 local setup_builtin_hl_groups = function()
     local whitespace_hl = get "Whitespace"
     local line_nr_hl = get "LineNr"
+    local normal_hl = get "Normal"
     local ibl_indent_hl_name = "IblIndent"
     local ibl_whitespace_hl_name = "IblWhitespace"
     local ibl_scope_hl_name = "IblScope"
+    local ibl_scope_char_hl_name = "IblScopeChar"
+    local ibl_char_hl_name = "IblChar"
 
     if not_set(get(ibl_indent_hl_name)) then
         vim.api.nvim_set_hl(0, ibl_indent_hl_name, whitespace_hl)
@@ -40,6 +43,12 @@ local setup_builtin_hl_groups = function()
     end
     if not_set(get(ibl_scope_hl_name)) then
         vim.api.nvim_set_hl(0, ibl_scope_hl_name, line_nr_hl)
+    end
+    if not_set(get(ibl_scope_char_hl_name)) then
+        vim.api.nvim_set_hl(0, ibl_scope_char_hl_name, normal_hl)
+    end
+    if not_set(get(ibl_char_hl_name)) then
+        vim.api.nvim_set_hl(0, ibl_char_hl_name, normal_hl)
     end
 end
 


### PR DESCRIPTION
IblScopeChar and IblChar were missing.

Without this change, it's possible to trigger the "No highlight group found" path for those names.
For example, I use the plugin junegunn/goyo.vim which when activated, pushes some theme/highlight changes to create a distraction-free writing environment.
When _exiting_ goyo mode, the missing name errors occur. I didn't inspect the code much, just noticed some of the builtin groups were not set in the relevant setup function, and adding them seemed to resolve my issue.

I don't know what the best initial values to setup would be, but I chose to copy from Normal.
My casual inference was the *Char was generic sounding enough to warrant copying "normal text".
My only visual inspection of the results is that it looks fine to my non-aesthete eyes.

It's possible that goyo is still doing something wrong here, but facially this seems like the correct thing to do.