### PR TITLE
feat: support empty foldtext in nvim 0.10

### DIFF
--- a/lua/ibl/init.lua
+++ b/lua/ibl/init.lua
@@ -213,6 +213,8 @@ M.refresh = function(bufnr)
         indent_opts.vartabstop = ""
     end
 
+    local has_empty_foldtext = utils.has_empty_foldtext(bufnr)
+
     local indent_state
     local next_whitespace_tbl = {}
     local empty_line_counter = 0
@@ -316,7 +318,7 @@ M.refresh = function(bufnr)
 
         local whitespace = utils.get_whitespace(line)
         local foldclosed = utils.get_foldclosed(bufnr, row)
-        if is_current_buffer and foldclosed == row then
+        if is_current_buffer and foldclosed == row and not has_empty_foldtext then
             local foldtext = utils.get_foldtextresult(bufnr, row)
             local foldtext_whitespace = utils.get_whitespace(foldtext)
             if vim.fn.strdisplaywidth(foldtext_whitespace, 0) < vim.fn.strdisplaywidth(whitespace, 0) then

--- a/lua/ibl/utils.lua
+++ b/lua/ibl/utils.lua
@@ -396,6 +396,19 @@ M.get_foldtextresult = function(bufnr, row)
 end
 
 ---@param bufnr number
+---@return boolean
+M.has_empty_foldtext = function(bufnr)
+    if vim.fn.has "nvim-0.10" == 0 then
+        return false
+    end
+    local win = M.get_win(bufnr)
+    if not win then
+        return false
+    end
+    return vim.api.nvim_get_option_value("foldtext", { win = win }) == ""
+end
+
+---@param bufnr number
 ---@param config ibl.config
 M.is_buffer_active = function(bufnr, config)
     for _, filetype in ipairs(M.get_filetypes(bufnr)) do


### PR DESCRIPTION
Neovim 0.10 changed the behavior for when `'foldtext'` is empty. It now displays the line normally with highlighting.

`vim.fn.foldtextresult` does however not reflect this change and returns the previous foldtext, like `+--  4 lines folded`. This breaks the current implementation which checks if indentation lines can be displayed over the foldtext.

So until (if ever) this gets fixed, we need to do a custom check.

fix #901