### PR TITLE
fix: use `strwidth` instead of `strdisplaywidth`

### DIFF
--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -88,14 +88,14 @@ M.default_config = {
 ---@return boolean, string?
 local validate_char = function(char)
     if type(char) == "string" then
-        local length = vim.fn.strdisplaywidth(char)
+        local length = vim.fn.strwidth(char)
         return length <= 1, string.format("'%s' has a display width of %d", char, length)
     else
         if #char == 0 then
             return false, "table is empty"
         end
         for i, c in ipairs(char) do
-            local length = vim.fn.strdisplaywidth(c)
+            local length = vim.fn.strwidth(c)
             if length > 1 then
                 return false, string.format("index %d '%s' has a display width of %d", i, c, length)
             end

--- a/lua/ibl/virt_text.lua
+++ b/lua/ibl/virt_text.lua
@@ -88,7 +88,7 @@ M.get = function(
 
         if indent.is_indent(ws) then
             whitespace_hl = utils.tbl_get_index(highlights.whitespace, indent_index).char
-            if vim.fn.strdisplaywidth(char) == 0 then
+            if vim.fn.strwidth(char) == 0 then
                 char = char_map[whitespace.SPACE] --[[@as string]]
                 sa = false
             else
@@ -108,7 +108,7 @@ M.get = function(
 
                 if config.scope.char then
                     local scope_char = get_char(config.scope.char, scope_index)
-                    if vim.fn.strdisplaywidth(scope_char) == 1 then
+                    if vim.fn.strwidth(scope_char) == 1 then
                         char = scope_char
                     end
                 end


### PR DESCRIPTION
`strdisplaywidth` is broken when called while loading a buffer. For example on `BufReadPost`.

fix #832