### PR TITLE
Add Perl to scope languages

### DIFF
--- a/lua/ibl/scope_languages.lua
+++ b/lua/ibl/scope_languages.lua
@@ -336,6 +336,10 @@ local M = {
 
         exceptionHandler = true,
     },
+    perl = {
+        block = true,
+        block_statement = true,
+    },
     php = {
         class_declaration = true,
         method_declaration = true,


### PR DESCRIPTION
I think these are the only two nodes we need.  I been using this for a little while and the only problem I've noticed is due to a treesitter mistake (https://github.com/tree-sitter-perl/tree-sitter-perl/issues/177).