### PR TITLE
fix(php): anonymous_function_creation_expression replaced with anonymous_function

### DIFF
--- a/lua/ibl/scope_languages.lua
+++ b/lua/ibl/scope_languages.lua
@@ -344,7 +344,7 @@ local M = {
         class_declaration = true,
         method_declaration = true,
         function_definition = true,
-        anonymous_function_creation_expression = true,
+        anonymous_function = true,
     },
     pony = {
         use_statement = true,


### PR DESCRIPTION
This was updated recently in php treesitter
https://github.com/nvim-treesitter/nvim-treesitter/commit/ec8776ed9ef56ffe7a61e67b64d5d6b6aba2c631
https://github.com/tree-sitter/tree-sitter-php/commit/0d3959bbd404c91535c8f913586561094f41fe54