### PR TITLE
chore: add doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .ci/*
+/doc/tags


### PR DESCRIPTION
`:helptags ALL` creates this file and `git status` then keeps telling me about it. Other nvim plugins have this in their .gitignores, so add it here as well to silence it.