### PR TITLE
feat: Support user defined scope languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This plugin requires the latest stable version of Neovim.
 
 ## Install
 
-Use your favourite plugin manager to install.
+Use your favorite plugin manager to install.
 
 For [lazy.nvim](https://github.com/folke/lazy.nvim):
 

--- a/lua/ibl/hooks.lua
+++ b/lua/ibl/hooks.lua
@@ -48,7 +48,7 @@ local count = 0
 --- Each hook type takes a callback a different function, and a configuration table
 ---@param type ibl.hooks.type
 ---@param cb function
----@param opts ibl.hooks.options
+---@param opts ibl.hooks.options?
 ---@overload fun(type: 'ACTIVE', cb: ibl.hooks.cb.active, opts: ibl.hooks.options?): string
 ---@overload fun(type: 'SCOPE_ACTIVE', cb: ibl.hooks.cb.scope_active, opts: ibl.hooks.options?): string
 ---@overload fun(type: 'SKIP_LINE', cb: ibl.hooks.cb.skip_line, opts: ibl.hooks.options?): string

--- a/lua/ibl/scope.lua
+++ b/lua/ibl/scope.lua
@@ -58,7 +58,7 @@ M.get = function(bufnr, config)
     end
 
     local lang = lang_tree:lang()
-    if not scope_lang[lang] then
+    if not scope_lang[lang] and not config.scope.include.node_type[lang] then
         return nil
     end
 


### PR DESCRIPTION
Node types for languages defined in `:help ibl.config.scope.include.node_type` will work, even if the language does not have support out of the box.

fix #926