### PR TITLE
fix: scope logic with unknown language

### DIFF
--- a/lua/ibl/scope.lua
+++ b/lua/ibl/scope.lua
@@ -76,7 +76,7 @@ M.get = function(bufnr, config)
         local type = node:type()
 
         if
-            (scope_lang[lang][type] and not utils.tbl_contains(excluded_node_types, type))
+            ((scope_lang[lang] and scope_lang[lang][type]) and not utils.tbl_contains(excluded_node_types, type))
             or utils.tbl_contains(include_node_types, type)
             or utils.tbl_contains(include_node_types, "*")
         then


### PR DESCRIPTION
If the language is not listed in the languages "officially" supported by ibl, `scope[lang]` is `nil`.