### PR TITLE
fix: don't allow empty scope

### DIFF
--- a/lua/ibl/init.lua
+++ b/lua/ibl/init.lua
@@ -244,6 +244,7 @@ M.refresh = function(bufnr)
     local scope_row_start, scope_col_start, scope_row_end, scope_col_end = -1, -1, -1, -1
     local scope_index = -1
     if scope then
+        ---@diagnostic disable-next-line: cast-local-type
         scope_row_start, scope_col_start, scope_row_end, scope_col_end = scope:range()
         scope_row_start, scope_col_start, scope_row_end = scope_row_start + 1, scope_col_start + 1, scope_row_end + 1
     end

--- a/lua/ibl/scope.lua
+++ b/lua/ibl/scope.lua
@@ -72,7 +72,7 @@ M.get = function(bufnr, config)
     local include_node_types =
         utils.tbl_join(config.scope.include.node_type["*"] or {}, config.scope.include.node_type[lang] or {})
 
-    while node do
+    while node and node:byte_length() > 0 do
         local type = node:type()
 
         if


### PR DESCRIPTION
There seems to be a bug in treesitter that allows an infinite loop of node parents, if the node is empty.
IBL doesn't care about the node if it's empty anyway, so we can just ignore them.

fix #930