### PR TITLE
feat: use faster version of `vim.validate` if available

### DIFF
--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -137,7 +137,7 @@ local validate_config = function(config)
             repeat_linebreak = { config.indent.repeat_linebreak, "boolean", true },
         }, config.indent, "ibl.config.indent")
         if config.indent.char then
-            vim.validate {
+            utils.validate {
                 char = {
                     config.indent.char,
                     validate_char,
@@ -146,7 +146,7 @@ local validate_config = function(config)
             }
         end
         if config.indent.tab_char then
-            vim.validate {
+            utils.validate {
                 tab_char = {
                     config.indent.tab_char,
                     validate_char,
@@ -155,7 +155,7 @@ local validate_config = function(config)
             }
         end
         if type(config.indent.highlight) == "table" then
-            vim.validate {
+            utils.validate {
                 tab_char = {
                     config.indent.highlight,
                     function(highlight)
@@ -173,7 +173,7 @@ local validate_config = function(config)
             remove_blankline_trail = { config.whitespace.remove_blankline_trail, "boolean", true },
         }, config.whitespace, "ibl.config.whitespace")
         if type(config.whitespace.highlight) == "table" then
-            vim.validate {
+            utils.validate {
                 tab_char = {
                     config.whitespace.highlight,
                     function(highlight)
@@ -199,7 +199,7 @@ local validate_config = function(config)
             exclude = { config.scope.exclude, "table", true },
         }, config.scope, "ibl.config.scope")
         if config.scope.char then
-            vim.validate {
+            utils.validate {
                 char = {
                     config.scope.char,
                     validate_char,
@@ -208,7 +208,7 @@ local validate_config = function(config)
             }
         end
         if type(config.scope.highlight) == "table" then
-            vim.validate {
+            utils.validate {
                 tab_char = {
                     config.scope.highlight,
                     function(highlight)

--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -110,7 +110,7 @@ local validate_config = function(config)
         return
     end
 
-    utils.validate({
+    utils.validate_config({
         enabled = { config.enabled, "boolean", true },
         debounce = { config.debounce, "number", true },
         viewport_buffer = { config.viewport_buffer, "table", true },
@@ -121,14 +121,14 @@ local validate_config = function(config)
     }, config, "ibl.config")
 
     if config.viewport_buffer then
-        utils.validate({
+        utils.validate_config({
             min = { config.viewport_buffer.min, "number", true },
             max = { config.viewport_buffer.max, "number", true },
         }, config.viewport_buffer, "ibl.config.viewport_buffer")
     end
 
     if config.indent then
-        utils.validate({
+        utils.validate_config({
             char = { config.indent.char, { "string", "table" }, true },
             tab_char = { config.indent.char, { "string", "table" }, true },
             highlight = { config.indent.highlight, { "string", "table" }, true },
@@ -168,7 +168,7 @@ local validate_config = function(config)
     end
 
     if config.whitespace then
-        utils.validate({
+        utils.validate_config({
             highlight = { config.whitespace.highlight, { "string", "table" }, true },
             remove_blankline_trail = { config.whitespace.remove_blankline_trail, "boolean", true },
         }, config.whitespace, "ibl.config.whitespace")
@@ -186,7 +186,7 @@ local validate_config = function(config)
     end
 
     if config.scope then
-        utils.validate({
+        utils.validate_config({
             enabled = { config.scope.enabled, "boolean", true },
             char = { config.scope.char, { "string", "table" }, true },
             show_start = { config.scope.show_start, "boolean", true },
@@ -219,13 +219,13 @@ local validate_config = function(config)
             }
         end
         if config.scope.exclude then
-            utils.validate({
+            utils.validate_config({
                 language = { config.scope.exclude.language, "table", true },
                 node_type = { config.scope.exclude.node_type, "table", true },
             }, config.scope.exclude, "ibl.config.scope.exclude")
         end
         if config.scope.include then
-            utils.validate({
+            utils.validate_config({
                 node_type = { config.scope.include.node_type, "table", true },
             }, config.scope.include, "ibl.config.scope.include")
         end
@@ -233,7 +233,7 @@ local validate_config = function(config)
 
     if config.exclude then
         if config.exclude then
-            utils.validate({
+            utils.validate_config({
                 filetypes = { config.exclude.filetypes, "table", true },
                 buftypes = { config.exclude.buftypes, "table", true },
             }, config.exclude, "ibl.config.exclude")

--- a/lua/ibl/hooks.lua
+++ b/lua/ibl/hooks.lua
@@ -58,7 +58,7 @@ local count = 0
 ---@overload fun(type: 'CLEAR', cb: ibl.hooks.cb.clear, opts: ibl.hooks.options?): string
 ---@overload fun(type: 'HIGHLIGHT_SETUP', cb: ibl.hooks.cb.highlight_setup, opts: ibl.hooks.options?): string
 M.register = function(type, cb, opts)
-    vim.validate {
+    utils.validate {
         type = {
             type,
             function(t)
@@ -70,7 +70,7 @@ M.register = function(type, cb, opts)
         opts = { opts, "table", true },
     }
     opts = vim.tbl_deep_extend("keep", opts or {}, default_opts)
-    vim.validate {
+    utils.validate {
         bufnr = { opts.bufnr, "number", true },
     }
     if opts.bufnr then
@@ -105,7 +105,7 @@ end
 ---
 ---@param id string
 M.clear = function(id)
-    vim.validate { id = { id, "string" } }
+    utils.validate { id = { id, "string" } }
     local type, hook_id = unpack(utils.split(id, "_"))
     if not type or not hook_id or not utils.tbl_contains(M.type, type) then
         return

--- a/lua/ibl/utils.lua
+++ b/lua/ibl/utils.lua
@@ -12,7 +12,7 @@ end
 ---@param opt table
 ---@param input table
 ---@param path string
-M.validate = function(opt, input, path)
+M.validate_config = function(opt, input, path)
     vim.validate(opt)
     for key, _ in pairs(input) do
         if not opt[key] then

--- a/lua/ibl/utils.lua
+++ b/lua/ibl/utils.lua
@@ -9,11 +9,29 @@ M.get_whitespace = function(line)
     return string.match(line, "^%s+") or ""
 end
 
+--- Use the faster validate version if available.
+--- NOTE: We disable some Lua diagnostics here since lua_ls isn't smart enough to
+--- realize that we're using an overloaded function.
+---@param spec table<string, {[1]:any, [2]:function|string, [3]:string|true|nil}>
+M.validate = function(spec)
+    if vim.fn.has "nvim-0.11" == 1 then
+        for key, key_spec in pairs(spec) do
+            local message = type(key_spec[3]) == "string" and key_spec[3] or nil --[[@as string?]]
+            local optional = type(key_spec[3]) == "boolean" and key_spec[3] or nil --[[@as boolean?]]
+            ---@diagnostic disable-next-line:param-type-mismatch, redundant-parameter
+            vim.validate(key, key_spec[1], key_spec[2], optional, message)
+        end
+    else
+        ---@diagnostic disable-next-line:param-type-mismatch
+        vim.validate(spec)
+    end
+end
+
 ---@param opt table
 ---@param input table
 ---@param path string
 M.validate_config = function(opt, input, path)
-    vim.validate(opt)
+    M.validate(opt)
     for key, _ in pairs(input) do
         if not opt[key] then
             error(string.format("'%s' is not a valid key of %s", key, path))


### PR DESCRIPTION
The form of `vim.validate` that takes a spec table as input was deprecated in https://github.com/neovim/neovim/pull/30855 and plugins should now use the faster version introduced in https://github.com/neovim/neovim/pull/28977.

This PR adds a new utility function to use the faster version if available. Also defined the existing `utils.validate` function to avoid confusion with the new utility function.