### PR TITLE
refactor: remove redundant conditional

### DIFF
--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -231,7 +231,6 @@ local validate_config = function(config)
         end
     end
 
-    
     if config.exclude then
         utils.validate_config({
             filetypes = { config.exclude.filetypes, "table", true },

--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -231,13 +231,12 @@ local validate_config = function(config)
         end
     end
 
+    
     if config.exclude then
-        if config.exclude then
-            utils.validate_config({
-                filetypes = { config.exclude.filetypes, "table", true },
-                buftypes = { config.exclude.buftypes, "table", true },
-            }, config.exclude, "ibl.config.exclude")
-        end
+        utils.validate_config({
+            filetypes = { config.exclude.filetypes, "table", true },
+            buftypes = { config.exclude.buftypes, "table", true },
+        }, config.exclude, "ibl.config.exclude")
     end
 end
 


### PR DESCRIPTION
Removes one of the nested conditionals:

```lua
if config.exclude then
    if config.exclude then
```