### PR TITLE
fix: correct copy-pasta in config.indent validation

### DIFF
--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -130,7 +130,7 @@ local validate_config = function(config)
     if config.indent then
         utils.validate_config({
             char = { config.indent.char, { "string", "table" }, true },
-            tab_char = { config.indent.char, { "string", "table" }, true },
+            tab_char = { config.indent.tab_char, { "string", "table" }, true },
             highlight = { config.indent.highlight, { "string", "table" }, true },
             smart_indent_cap = { config.indent.smart_indent_cap, "boolean", true },
             priority = { config.indent.priority, "number", true },


### PR DESCRIPTION
Looks like we're passing in `char` when trying to validate `tab_char`.