### PR TITLE
fix: indexing field 'uv' (a nil value) in indent-blankline.nvim/lua/ilb/inlay_hints.lua

### DIFF
--- a/lua/ibl/inlay_hints.lua
+++ b/lua/ibl/inlay_hints.lua
@@ -8,7 +8,8 @@ local handler = nil
 ---@type table<number, number[]>
 local buffer_state = {}
 
-local inlay_hint_timer = vim.uv.new_timer()
+local uv = vim.uv or vim.loop
+local inlay_hint_timer = uv.new_timer()
 
 ---@param bufnr number
 ---@param row number


### PR DESCRIPTION
indexing vim.uv (uv == nil) crashes the plugin and eventually any plugin loaded after it won't work properly.
NVIM v0.9.4
LuaJIT 2.1.1692716794