### PR TITLE
fix: compat with felpafel/inlay-hint.nvim

### DIFF
--- a/lua/ibl/config.lua
+++ b/lua/ibl/config.lua
@@ -37,6 +37,7 @@ M.default_config = {
     },
     scope = {
         enabled = true,
+        highlight_inlay_hints = true,
         char = nil,
         show_start = true,
         show_end = true,
@@ -188,6 +189,7 @@ local validate_config = function(config)
     if config.scope then
         utils.validate_config({
             enabled = { config.scope.enabled, "boolean", true },
+            highlight_inlay_hints = { config.scope.highlight_inlay_hints, "boolean", true },
             char = { config.scope.char, { "string", "table" }, true },
             show_start = { config.scope.show_start, "boolean", true },
             show_end = { config.scope.show_end, "boolean", true },

--- a/lua/ibl/config.types.lua
+++ b/lua/ibl/config.types.lua
@@ -56,6 +56,8 @@
 ---@class ibl.config.scope
 --- Enables or disables scope
 ---@field enabled boolean?
+--- Whether inlay hints should be highlighted
+---@field highlight_inlay_hints boolean?
 --- Character, or list of characters, that get used to display the scope indentation guide
 ---
 --- Each character has to have a display width of 0 or 1

--- a/lua/ibl/init.lua
+++ b/lua/ibl/init.lua
@@ -20,7 +20,9 @@ local global_buffer_state = {}
 ---@param bufnr number
 local clear_buffer = function(bufnr)
     vt.clear_buffer(bufnr)
-    inlay_hints.clear_buffer(bufnr)
+    if conf.get_config(bufnr).scope.highlight_inlay_hints then
+        inlay_hints.clear_buffer(bufnr)
+    end
     for _, fn in pairs(hooks.get(bufnr, hooks.type.CLEAR)) do
         fn(bufnr)
     end
@@ -229,7 +231,7 @@ M.refresh = function(bufnr)
 
     local same_scope = (scope and scope:id()) == (buffer_state.scope and buffer_state.scope:id())
 
-    if not same_scope then
+    if not same_scope and conf.get_config(bufnr).scope.highlight_inlay_hints then
         inlay_hints.clear_buffer(bufnr)
     end
 
@@ -455,7 +457,9 @@ M.refresh = function(bufnr)
                 priority = config.scope.priority,
                 strict = false,
             })
-            inlay_hints.set(bufnr, row - 1, #whitespace, scope_hl.underline, scope_hl.underline)
+            if conf.get_config(bufnr).scope.highlight_inlay_hints then
+                inlay_hints.set(bufnr, row - 1, #whitespace, scope_hl.underline, scope_hl.underline)
+            end
         end
 
         -- Scope end
@@ -466,7 +470,9 @@ M.refresh = function(bufnr)
                 priority = config.scope.priority,
                 strict = false,
             })
-            inlay_hints.set(bufnr, row - 1, #whitespace, scope_hl.underline, scope_hl.underline)
+            if conf.get_config(bufnr).scope.highlight_inlay_hints then
+                inlay_hints.set(bufnr, row - 1, #whitespace, scope_hl.underline, scope_hl.underline)
+            end
         end
 
         for _, fn in


### PR DESCRIPTION
Indent Blankline was deleting [felpafel/inlay-hint.nvim](https://github.com/felpafel/inlay-hint.nvim)'s `eol` hints and overriding said plugin's highlight group config.

This PR creates the new option `scope.highlight_inlay_hints`, which when disabled fixes this issue.